### PR TITLE
Replace deprecated numpy code

### DIFF
--- a/climlab/domain/field.py
+++ b/climlab/domain/field.py
@@ -273,7 +273,7 @@ def to_latlon(array, domain, axis = 'lon'):
 
     """
     #  if array is latitude dependent (has the same shape as lat)
-    axis, array, depth = np.meshgrid(domain.axes[axis].points, array,
+    theaxis, array, depth = np.meshgrid(domain.axes[axis].points, array,
                                     domain.axes['depth'].points)
     if axis == 'lat':
     #  if array is longitude dependent (has the same shape as lon)

--- a/climlab/radiation/__init__.py
+++ b/climlab/radiation/__init__.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 from .aplusbt import AplusBT, AplusBT_CO2
 from .absorbed_shorwave import SimpleAbsorbedShortwave
 from .boltzmann import Boltzmann
+from .greygas import GreyGas, GreyGasSW
 from .insolation import FixedInsolation, P2Insolation, AnnualMeanInsolation, DailyInsolation
 from .nband import NbandRadiation, ThreeBandSW
 from .water_vapor import ManabeWaterVapor

--- a/climlab/radiation/greygas.py
+++ b/climlab/radiation/greygas.py
@@ -11,7 +11,7 @@ class GreyGas(EnergyBudget):
     including grey and semi-grey model.
 
     Input argument absorptivity is band absorptivity
-    (should same size as grid).
+    (should be same size as the grid).
 
     By default emissivity = absorptivity.
     Subclasses can override this is necessary (e.g. for shortwave model).

--- a/climlab/radiation/transmissivity.py
+++ b/climlab/radiation/transmissivity.py
@@ -96,7 +96,7 @@ class Transmissivity(object):
             E0 \\\\
             E1 \\\\
             E2 \\\\
-            emit_sfc + albedo_sfc * D[-1]
+            emit_{sfc} + albedo_{sfc} * D[-1]
         \\end{array} \\right]
 
     So that the upwelling flux is

--- a/climlab/radiation/transmissivity.py
+++ b/climlab/radiation/transmissivity.py
@@ -61,7 +61,7 @@ class Transmissivity(object):
 
     .. math::
 
-        Tdown= \\left[ \\begin{array}{cccc}
+        T_{down} = \\left[ \\begin{array}{cccc}
                                1 &               0 &       0 &  0   \\\\
                          \\tau_0 &               1 &       0 &  0   \\\\
                  \\tau_0 \\tau_1 &         \\tau_1 &       1 &  0   \\\\
@@ -74,8 +74,8 @@ class Transmissivity(object):
 
     .. math::
         
-        Edown = \\left[ \\begin{array}{c}
-            fromspace \\\\
+        E_{down} = \\left[ \\begin{array}{c}
+            \text{flux_from_space} \\\\
             E0 \\\\
             E1 \\\\
             E2 \\\\

--- a/climlab/radiation/transmissivity.py
+++ b/climlab/radiation/transmissivity.py
@@ -1,8 +1,6 @@
 from __future__ import division
 from builtins import object
 import numpy as np
-# experimental...  this is not well documented!
-from numpy.core.umath_tests import matrix_multiply
 
 '''
 Testing multi-dimensional column radiation
@@ -54,8 +52,8 @@ class Transmissivity(object):
         A= \\left[ \\begin{array}{cccc}
         1       & 1         & 1         & 1         \\\\
         \\tau_0 & 1         & 1         & 1         \\\\
-        \\tau_0 & \\tau_1   & 1         & 1         \\\\
-        \\tau_0 & \\tau_1   & \\tau_2   & 1         \\\\
+        \\tau_1 & \\tau_1   & 1         & 1         \\\\
+        \\tau_2 & \\tau_2   & \\tau_2   & 1         \\\\
         \\end{array} \\right]
 
     We then take the cumulative product along columns,
@@ -63,20 +61,27 @@ class Transmissivity(object):
 
     .. math::
 
-        Tup= \\left[ \\begin{array}{cccc}
+        Tdown= \\left[ \\begin{array}{cccc}
                                1 &               0 &       0 &  0   \\\\
                          \\tau_0 &               1 &       0 &  0   \\\\
-                 \\tau_1 \\tau_0 &         \\tau_1 &       1 &  0   \\\\
-        \\tau_2 \\tau_1 \\tau_00 & \\tau_2 \\tau_1 & \\tau_2 &  1   \\\\
+                 \\tau_0 \\tau_1 &         \\tau_1 &       1 &  0   \\\\
+        \\tau_0 \\tau_1 \\tau_2 & \\tau_1 \\tau_2 & \\tau_2 &  1   \\\\
         \\end{array} \\right]
 
-    and Tdown = transpose(Tup)
+    and Tup = transpose(Tdown)
 
-    Construct an emission vector for the downwelling beam:
+    Construct a column emission vector for the downwelling beam:
 
-    Edown = [E0, E1, E2, fromspace]
+    .. math::
+        
+        Edown = \\left[ \\begin{array}{c}
+            fromspace \\\\
+            E0 \\\\
+            E1 \\\\
+            E2 \\\\
+        \\end{array} \\right]
 
-    Now we can get the downwelling beam by matrix multiplication:
+    Now we can get the downwelling beam at layer interfaces by matrix multiplication:
 
     D = Tdown * Edown
 
@@ -84,6 +89,15 @@ class Transmissivity(object):
     at the surface to the surface emissions:
 
     Eup = [emit_sfc + albedo_sfc*D[0], E0, E1, E2]
+
+    .. math::
+        
+        Eup = \\left[ \\begin{array}{c}
+            E0 \\\\
+            E1 \\\\
+            E2 \\\\
+            emit_sfc + albedo_sfc * D[-1]
+        \\end{array} \\right]
 
     So that the upwelling flux is
 
@@ -93,7 +107,7 @@ class Transmissivity(object):
 
     F = U - D
 
-    The absorbed radiation at the surface is then -F[0]
+    The absorbed radiation at the surface is then -F[-1]
     The absorbed radiation in the atmosphere is the flux convergence:
 
     -diff(F)
@@ -102,8 +116,6 @@ class Transmissivity(object):
     #  quick hack to get some simple cloud albedo
     def __init__(self, absorptivity, reflectivity=None, axis=0):
         self.axis = axis
-        #if absorptivity.ndim is not 1:
-        #    raise ValueError('absorptivity argument must be a vector')
         if reflectivity is None:
             reflectivity = np.zeros_like(absorptivity)
         self.reflectivity = reflectivity
@@ -117,7 +129,6 @@ class Transmissivity(object):
         self.Tup = Tup
         self.Tdown = Tdown
 
-    #def flux_down(self, fluxDownTop, emission=None):
     def flux_up(self, fluxUpBottom, emission=None):
         '''Compute downwelling radiative flux at interfaces between layers.
 
@@ -137,15 +148,12 @@ class Transmissivity(object):
             emission = np.zeros_like(self.absorptivity)
         E = np.concatenate((emission, np.atleast_1d(fluxUpBottom)), axis=-1)
         #  dot product (matrix multiplication) along last axes
-        return np.squeeze(matrix_multiply(self.Tup, E[..., np.newaxis]))
+        return np.squeeze(np.matmul(self.Tup, E[..., np.newaxis]))
 
     def flux_reflected_up(self, fluxDown, albedo_sfc=0.):
-        #reflectivity = np.concatenate((np.atleast_1d(albedo_sfc),
-        #                               self.reflectivity), axis=-1)
         reflectivity = np.concatenate((self.reflectivity, np.atleast_1d(albedo_sfc)), axis=-1)
         return reflectivity*fluxDown
 
-    #def flux_up(self, fluxUpBottom, emission=None):
     def flux_down(self, fluxDownTop, emission=None):
         '''Compute upwelling radiative flux at interfaces between layers.
 
@@ -164,22 +172,10 @@ class Transmissivity(object):
             emission = np.zeros_like(self.absorptivity)
         E = np.concatenate((np.atleast_1d(fluxDownTop),emission), axis=-1)
         #  dot product (matrix multiplication) along last axes
-        return np.squeeze(matrix_multiply(self.Tdown, E[..., np.newaxis]))
-#
-#def compute_T(transmissivity):
-#    # fully vectorized version
-#    # works on a vector transmissivity
-#    N = transmissivity.size
-#    tau = np.concatenate((np.atleast_1d(1.), transmissivity))
-#    B = np.tile(tau, (N+1,1)).transpose()
-#    A = np.tril(B,k=-1) + np.tri(N+1).transpose()
-#    Tup = np.tril(np.cumprod(A, axis=0))
-#    Tdown = np.transpose(Tup)
-#    return Tup, Tdown
+        return np.squeeze(np.matmul(self.Tdown, E[..., np.newaxis]))
 
 def compute_T_vectorized(transmissivity):
-    #  really vectorized version... to work with arbitrary dimensions
-    #  of input transmissivity
+    #  really vectorized version... to work with arbitrary dimensions of input transmissivity
     #  Assumption is the last dimension of transmissivity is vertical
     trans_shape = np.shape(transmissivity)
     N = trans_shape[-1]
@@ -187,37 +183,11 @@ def compute_T_vectorized(transmissivity):
     ones = np.ones(otherdims)[..., np.newaxis]
     tau = np.concatenate((ones, transmissivity), axis=-1)
     tiletau = np.tile(tau[..., np.newaxis],N+1)
-    # equivalent to taking transpose of last two axes
-    #B = np.rollaxis(tiletau, -1, -2)
-    B = tiletau
     matdims = np.append(np.array(otherdims),[1,1])
     # dimensions of matrix should be [otherdims,N+1,N+1]
     tri = np.tile(np.tri(N+1).transpose(),matdims)
-    #  np.tril refuses to broadcast over other dims in numpy < 1.9
-    #  use a custom version instead, below
-    #  Performance is BETTER with numpy 1.9
-    A = tril(B,k=-1) + tri
-    #Tup = tril(np.cumprod(A, axis=-2))
-    ##  transpose over last two axes
-    #Tdown = np.rollaxis(Tup, -1, -2)
-    Tdown = tril(np.cumprod(A, axis=-2))
+    A = np.tril(tiletau,k=-1) + tri
+    Tdown = np.tril(np.cumprod(A, axis=-2))
     #  transpose over last two axes
     Tup = np.rollaxis(Tdown, -1, -2)
     return Tup, Tdown
-
-
-def tril(array, k=0):
-    '''Lower triangle of an array.
-    Return a copy of an array with elements above the k-th diagonal zeroed.
-    Need a multi-dimensional version here because numpy.tril does not
-    broadcast for numpy verison < 1.9.'''
-    try:
-        tril_array = np.tril(array, k=k)
-    except:
-        # have to loop
-        tril_array = np.zeros_like(array)
-        shape = array.shape
-        otherdims = shape[:-2]
-        for index in np.ndindex(otherdims):
-            tril_array[index] = np.tril(array[index], k=k)
-    return tril_array

--- a/docs/source/api/climlab.radiation.rst
+++ b/docs/source/api/climlab.radiation.rst
@@ -17,7 +17,7 @@ climlab.radiation
    climlab.radiation.AplusBT
    climlab.radiation.Boltzmann
    climlab.radiation.CAM3
-   climlab.radiation.GreyGas
+   climlab.radiation.greygas
    climlab.radiation.insolation
    climlab.radiation.nband
    climlab.radiation.Radiation


### PR DESCRIPTION
This should fix #182 

Also cleaning up some documentation, and addressing a problem I just noticed:

The classes`climlab.radiation.greygas.GreyGas` and `climlab.radiation.greygas.GreyGasSW` don't appear in the [API documentation for the radiation module](https://climlab.readthedocs.io/en/latest/api/climlab.radiation.html).