### PR TITLE
Add Python 3.11 tests and drop Python 3.7

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [Ubuntu, macOS, Windows]
         include:
           - os: Ubuntu

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ These are handled automatically if you install with conda_.
 
 Required
 ~~~~~~~~~~~~
-- Python (currently testing on versions 3.7, 3.8, 3.9, 3.10)
+- Python (currently testing on versions 3.8, 3.9, 3.10, 3.11)
 - numpy
 - scipy
 - future

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -96,7 +96,7 @@ These are handled automatically if you install with conda_.
 
 Required
 ------------
-- Python (currently testing on versions 3.7, 3.8, 3.9, 3.10)
+- Python (currently testing on versions 3.8, 3.9, 3.10, 3.11)
 - numpy
 - scipy
 - future


### PR DESCRIPTION
Does climlab build and test properly under Python 3.11?