### PR TITLE
Support for aerosols in RRTMG

### DIFF
--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -70,7 +70,7 @@ class RRTMG(_Radiation_SW, _Radiation_LW):
             asmc_sw = 0.,  # In-cloud asymmetry parameter
             fsfc_sw = 0.,  # In-cloud forward scattering fraction (delta function pointing forward "forward peaked scattering")
             # AEROSOLS
-            iaer_sw = 0,   #! Aerosol option flag
+            iaer    = 0,   #! Aerosol option flag
                            #!    0: No aerosol
                            #!    6: ECMWF method: use six ECMWF aerosol types input aerosol optical depth at 0.55 microns for each aerosol type (ecaer)
                            #!    10:Input aerosol optical properties: input total aerosol optical depth, single scattering albedo and asymmetry parameter (tauaer, ssaaer, asmaer) directly
@@ -183,7 +183,7 @@ class RRTMG(_Radiation_SW, _Radiation_LW):
                      ssac = ssac_sw,
                      asmc = asmc_sw,
                      fsfc = fsfc_sw,
-                     iaer = iaer_sw,
+                     iaer = iaer,
                      tauaer = tauaer_sw,
                      ssaaer = ssaaer_sw,
                      asmaer = asmaer_sw,

--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -70,6 +70,10 @@ class RRTMG(_Radiation_SW, _Radiation_LW):
             asmc_sw = 0.,  # In-cloud asymmetry parameter
             fsfc_sw = 0.,  # In-cloud forward scattering fraction (delta function pointing forward "forward peaked scattering")
             # AEROSOLS
+            iaer_sw = 0,   #! Aerosol option flag
+                           #!    0: No aerosol
+                           #!    6: ECMWF method: use six ECMWF aerosol types input aerosol optical depth at 0.55 microns for each aerosol type (ecaer)
+                           #!    10:Input aerosol optical properties: input total aerosol optical depth, single scattering albedo and asymmetry parameter (tauaer, ssaaer, asmaer) directly
             tauaer_sw = 0.,   # Aerosol optical depth (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
             ssaaer_sw = 0.,   # Aerosol single scattering albedo (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
             asmaer_sw = 0.,   # Aerosol asymmetry parameter (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
@@ -179,6 +183,7 @@ class RRTMG(_Radiation_SW, _Radiation_LW):
                      ssac = ssac_sw,
                      asmc = asmc_sw,
                      fsfc = fsfc_sw,
+                     iaer = iaer_sw,
                      tauaer = tauaer_sw,
                      ssaaer = ssaaer_sw,
                      asmaer = asmaer_sw,

--- a/climlab/radiation/rrtm/rrtmg_lw.py
+++ b/climlab/radiation/rrtm/rrtmg_lw.py
@@ -51,10 +51,9 @@ class RRTMG_LW(_Radiation_LW):
         self.add_input('iceflglw', iceflglw)
         self.add_input('liqflglw', liqflglw)
         self.add_input('tauc', tauc)
-        self.add_input('tauaer', tauaer)
+        self.add_input('tauaer', self._spectral_field(tauaer))
         self.add_input('return_spectral_olr', return_spectral_olr)
 
-        self.tauaer = self._spectral_field(self.tauaer)
         # Spectrally-decomposed OLR
         if self.return_spectral_olr:
             # Adjust output flag

--- a/climlab/radiation/rrtm/rrtmg_lw.py
+++ b/climlab/radiation/rrtm/rrtmg_lw.py
@@ -104,13 +104,14 @@ class RRTMG_LW(_Radiation_LW):
         tauc = _climlab_to_rrtm(self.tauc * np.ones_like(self.Tatm))
         #  broadcast to get [nbndlw,ncol,nlay]
         tauc = tauc * np.ones([nbndlw,ncol,nlay])
-        # Aerosol optical depth at mid-point of LW spectral bands, needs to be [ncol,nlay,nbndlw]
-        tauaer = self.tauaer[..., ::-1]  #  flip pressure order
-        if len(self.Tatm.shape)==1:  #  (num_lev)
-            #  Need to append an extra dimension for singleton horizontal ncol
-            tauaer = tauaer[..., np.newaxis, :]  # [nbndlw, ncol, nlay]
-        # transpose to get [ncol,nlay,nbndlw]
-        tauaer = np.transpose(tauaer, (1,2,0))
+        tauaer = _climlab_to_rrtm(self.tauaer, spectral_axis=True)
+        # # Aerosol optical depth at mid-point of LW spectral bands, needs to be [ncol,nlay,nbndlw]
+        # tauaer = self.tauaer[..., ::-1]  #  flip pressure order
+        # if len(self.Tatm.shape)==1:  #  (num_lev)
+        #     #  Need to append an extra dimension for singleton horizontal ncol
+        #     tauaer = tauaer[..., np.newaxis, :]  # [nbndlw, ncol, nlay]
+        # # transpose to get [ncol,nlay,nbndlw]
+        # tauaer = np.transpose(tauaer, (1,2,0))
         args = [ncol, nlay, icld, ispec, permuteseed, irng, idrv, const.cp,
                 play, plev, tlay, tlev, tsfc,
                 h2ovmr, o3vmr, co2vmr, ch4vmr, n2ovmr, o2vmr,

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -111,24 +111,21 @@ class RRTMG_SW(_Radiation_SW):
         self.add_input('ssac', ssac)
         self.add_input('asmc', asmc)
         self.add_input('fsfc', fsfc)
-        self.add_input('tauaer', tauaer)
-        self.add_input('ssaaer', ssaaer)
-        self.add_input('asmaer', asmaer)
+        self.add_input('tauaer', self._spectral_field(tauaer))
+        self.add_input('ssaaer', self._spectral_field(ssaaer))
+        self.add_input('asmaer', self._spectral_field(asmaer))
         self.add_input('ecaer', ecaer)
         self.add_input('isolvar', isolvar)
         self.add_input('indsolvar', indsolvar)
         self.add_input('bndsolvar', bndsolvar)
         self.add_input('solcycfrac', solcycfrac)
 
-        self.tauaer = self._spectral_field(self.tauaer)
-        self.ssaaer = self._spectral_field(self.ssaaer)
-        self.asmaer = self._spectral_field(self.asmaer)
         # try:
         #     self.ecaer = Field(self.ecaer * np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), naerec, axis=0), 
         #                     domain=full_spectral_domain)
         # except:
         #     raise ValueError('Input value for ecaer has the wrong dimensions.')
-    def _spectral_field(field):
+    def _spectral_field(self, field):
         wavenum_ax = Axis(axis_type='abstract', bounds=wavenum_bounds)
         full_spectral_axes = {**self.Tatm.domain.axes, 'wavenumber': wavenum_ax}
         full_spectral_domain = domain._Domain(axes=full_spectral_axes)

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -114,17 +114,12 @@ class RRTMG_SW(_Radiation_SW):
         self.add_input('tauaer', self._spectral_field(tauaer))
         self.add_input('ssaaer', self._spectral_field(ssaaer))
         self.add_input('asmaer', self._spectral_field(asmaer))
-        self.add_input('ecaer', ecaer)
+        self.add_input('ecaer', ecaer * np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), naerec, axis=0))
         self.add_input('isolvar', isolvar)
         self.add_input('indsolvar', indsolvar)
         self.add_input('bndsolvar', bndsolvar)
         self.add_input('solcycfrac', solcycfrac)
 
-        # try:
-        #     self.ecaer = Field(self.ecaer * np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), naerec, axis=0), 
-        #                     domain=full_spectral_domain)
-        # except:
-        #     raise ValueError('Input value for ecaer has the wrong dimensions.')
     def _spectral_field(self, field):
         wavenum_ax = Axis(axis_type='abstract', bounds=wavenum_bounds)
         full_spectral_axes = {**self.Tatm.domain.axes, 'wavenumber': wavenum_ax}
@@ -190,8 +185,7 @@ class RRTMG_SW(_Radiation_SW):
         # Aerosol asymmetry parameter (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
         asmaer = _climlab_to_rrtm(self.asmaer, spectral_axis=True, reorder_sw_bands=True)
         # Aerosol optical depth at 0.55 micron (iaer=6 only), Dimensions,  (ncol,nlay,naerec)] #  (non-delta scaled)
-        #  STILL NEED TO IMPLEMENT THE CORRECT AXIS FOR THIS ONE
-        ecaer = np.transpose(_climlab_to_rrtm(self.ecaer * np.ones_like(self.Tatm)) * np.ones([naerec,ncol,nlay]), (1,2,0))
+        ecaer = _climlab_to_rrtm(self.ecaer, spectral_axis=True)
 
         args = [ncol, nlay, icld, iaer, permuteseed, irng,
                 play, plev, tlay, tlev, tsfc,

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -120,29 +120,21 @@ class RRTMG_SW(_Radiation_SW):
         self.add_input('bndsolvar', bndsolvar)
         self.add_input('solcycfrac', solcycfrac)
 
-        wavenum_ax = Axis(axis_type='abstract', bounds=wavenum_bounds)
-        full_spectral_axes = {**self.Tatm.domain.axes, 'wavenumber': wavenum_ax}
-        full_spectral_domain = domain._Domain(axes=full_spectral_axes)
-        try:
-            self.tauaer = Field(self.tauaer * np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), nbndsw, axis=0), 
-                            domain=full_spectral_domain)
-        except:
-            raise ValueError('Input value for tauaer has the wrong dimensions.')
-        try:
-            self.ssaaer = Field(self.ssaaer * np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), nbndsw, axis=0), 
-                            domain=full_spectral_domain)
-        except:
-            raise ValueError('Input value for ssaaer has the wrong dimensions.')
-        try:
-            self.asmaer = Field(self.asmaer * np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), nbndsw, axis=0), 
-                            domain=full_spectral_domain)
-        except:
-            raise ValueError('Input value for asmaer has the wrong dimensions.')
+        self.tauaer = self._spectral_field(self.tauaer)
+        self.ssaaer = self._spectral_field(self.ssaaer)
+        self.asmaer = self._spectral_field(self.asmaer)
         # try:
         #     self.ecaer = Field(self.ecaer * np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), naerec, axis=0), 
         #                     domain=full_spectral_domain)
         # except:
         #     raise ValueError('Input value for ecaer has the wrong dimensions.')
+    def _spectral_field(field):
+        wavenum_ax = Axis(axis_type='abstract', bounds=wavenum_bounds)
+        full_spectral_axes = {**self.Tatm.domain.axes, 'wavenumber': wavenum_ax}
+        full_spectral_domain = domain._Domain(axes=full_spectral_axes)
+        return Field(field * 
+                    np.repeat(np.ones_like(self.Tatm[np.newaxis, ...]), nbndsw, axis=0), 
+                    domain=full_spectral_domain)
 
     def _prepare_sw_arguments(self):
         #  prepare insolation

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -22,12 +22,13 @@ except:
 
 # Shortwave spectral band limits (wavenumbers in cm^-1)
 # Data copied from rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_init.f90
+band_numbers = np.array([29,16,17,18,19,20,21,22,23,24,25,26,27,28])
 wavenum_bounds = np.array([820., 2600., 3250., 4000., 4650., 5150., 6150., 7700., 8050., 
                             12850., 16000., 22650., 29000., 38000.,  50000.,])
 wavenum_delta = np.diff(wavenum_bounds)
-# For some reason the band 820 - 2600 cm-1 is the last element in RRTMG_SW instead of first element
-# Not sure right now if we should follow this ordering in climlab, or (more likely) reorder before passing to RRTMG_SW
-# should be able to reorder with np.roll(somearray, -1, axis=0)
+# For some reason the band 820 - 2600 cm-1 is the last element in RRTMG_SW (Band 29) 
+# instead of first element (Band 16)
+# Climlab will keep bands in numerical order by wavenumber and reorder before passing to RRTMG_SW
 
 class RRTMG_SW(_Radiation_SW):
     def __init__(self,
@@ -194,11 +195,11 @@ class RRTMG_SW(_Radiation_SW):
         # In-cloud forward scattering fraction (delta function pointing forward "forward peaked scattering")
         fsfc = _climlab_to_rrtm(self.fsfc * np.ones_like(self.Tatm)) * np.ones([nbndsw,ncol,nlay])
         # Aerosol optical depth (iaer=10 only), (ncol,nlay,nbndsw)] #  (non-delta scaled)
-        tauaer = _climlab_to_rrtm(self.tauaer, spectral_axis=True)
+        tauaer = _climlab_to_rrtm(self.tauaer, spectral_axis=True, reorder_sw_bands=True)
         # Aerosol single scattering albedo (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
-        ssaaer = _climlab_to_rrtm(self.ssaaer, spectral_axis=True)
+        ssaaer = _climlab_to_rrtm(self.ssaaer, spectral_axis=True, reorder_sw_bands=True)
         # Aerosol asymmetry parameter (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
-        asmaer = _climlab_to_rrtm(self.asmaer, spectral_axis=True)
+        asmaer = _climlab_to_rrtm(self.asmaer, spectral_axis=True, reorder_sw_bands=True)
         # Aerosol optical depth at 0.55 micron (iaer=6 only), Dimensions,  (ncol,nlay,naerec)] #  (non-delta scaled)
         #  STILL NEED TO IMPLEMENT THE CORRECT AXIS FOR THIS ONE
         ecaer = np.transpose(_climlab_to_rrtm(self.ecaer * np.ones_like(self.Tatm)) * np.ones([naerec,ncol,nlay]), (1,2,0))

--- a/climlab/radiation/rrtm/utils.py
+++ b/climlab/radiation/rrtm/utils.py
@@ -51,7 +51,7 @@ def interface_temperature(Ts, Tatm, **kwargs):
     Tinterp = np.concatenate((Ttoa[..., np.newaxis], Tinterp, Ts), axis=-1)
     return Tinterp
 
-def _climlab_to_rrtm(field, spectral_axis=False):
+def _climlab_to_rrtm(field, spectral_axis=False, reorder_sw_bands=False):
     '''Prepare field with proper dimension order.
     RRTM code expects arrays with (ncol, nlay)
     and with pressure decreasing from surface at element 0
@@ -64,9 +64,10 @@ def _climlab_to_rrtm(field, spectral_axis=False):
         But lat-lon grids not yet supported here!
 
     spectral_axis should be set to True if the field has an additional axis for spectral bands (nbndlw or nbndsw)
+    
+    reorder_sw_bands should be set to True for shortwave fields with spectral bands to account for RRTMG_SW band ordering
+    (ignored if spectral_axis=False)
     '''
-    # Make this work just with 1D (KM,) arrays
-    #  (KM,)  -->  (1, nlay)
     try:
         #  Flip along the last axis to reverse the pressure order
         field = field[..., ::-1]
@@ -80,14 +81,16 @@ def _climlab_to_rrtm(field, spectral_axis=False):
         num_dims -= 1
     if num_dims==1:  #  (num_lev)
         #  Need to append an extra dimension for singleton horizontal ncol
-        modfield = field[..., np.newaxis, :]
+        modfield = field[..., np.newaxis, :]  # [ncol,nlay] or [nbnd,ncol,nlay]
     elif num_dims==2:  # (num_lat, num_lev)
-        modfield = field
+        modfield = field  # [ncol,nlay] or [nbnd,ncol,nlay]
     elif num_dims > 2:
         raise ValueError('lat-lon grids not yet supported here.')
     #elif num_dims==3:  # (num_lat, num_lon, num_lev)
         #  Need to reshape this array
     if spectral_axis:
+        if reorder_sw_bands:
+            modfield = np.roll(modfield, -1, axis=0)  # Make Band 29 the last element of array
         # transpose to get [ncol,nlay,nbnd]
         modfield = np.transpose(modfield, (1,2,0))
     return modfield

--- a/climlab/radiation/rrtm/utils.py
+++ b/climlab/radiation/rrtm/utils.py
@@ -51,7 +51,7 @@ def interface_temperature(Ts, Tatm, **kwargs):
     Tinterp = np.concatenate((Ttoa[..., np.newaxis], Tinterp, Ts), axis=-1)
     return Tinterp
 
-def _climlab_to_rrtm(field):
+def _climlab_to_rrtm(field, spectral_axis=False):
     '''Prepare field with proper dimension order.
     RRTM code expects arrays with (ncol, nlay)
     and with pressure decreasing from surface at element 0
@@ -63,7 +63,7 @@ def _climlab_to_rrtm(field):
 
         But lat-lon grids not yet supported here!
 
-    Case single column
+    spectral_axis should be set to True if the field has an additional axis for spectral bands 
     '''
     # Make this work just with 1D (KM,) arrays
     #  (KM,)  -->  (1, nlay)
@@ -75,16 +75,22 @@ def _climlab_to_rrtm(field):
             return field
         else:
             raise ValueError('field must be array_like or scalar.')
-    shape = field.shape
-    if len(shape)==1:  #  (num_lev)
+    num_dims = len(field.shape)
+    if spectral_axis:
+        num_dims -= 1
+    if num_dims==1:  #  (num_lev)
         #  Need to append an extra dimension for singleton horizontal ncol
-        return field[np.newaxis, ...]
-    elif len(shape)==2:  # (num_lat, num_lev)
-        return field
-    elif len(shape) > 2:
+        modfield = field[..., np.newaxis, :]
+    elif num_dims==2:  # (num_lat, num_lev)
+        modfield = field
+    elif num_dims > 2:
         raise ValueError('lat-lon grids not yet supported here.')
-    #elif len(shape)==3:  # (num_lat, num_lon, num_lev)
+    #elif num_dims==3:  # (num_lat, num_lon, num_lev)
         #  Need to reshape this array
+    if spectral_axis:
+        # transpose to get [ncol,nlay,nbnd]
+        modfield = np.transpose(modfield, (1,2,0))
+    return modfield
 
 def _rrtm_to_climlab(field):
     try:

--- a/climlab/radiation/rrtm/utils.py
+++ b/climlab/radiation/rrtm/utils.py
@@ -63,7 +63,7 @@ def _climlab_to_rrtm(field, spectral_axis=False):
 
         But lat-lon grids not yet supported here!
 
-    spectral_axis should be set to True if the field has an additional axis for spectral bands 
+    spectral_axis should be set to True if the field has an additional axis for spectral bands (nbndlw or nbndsw)
     '''
     # Make this work just with 1D (KM,) arrays
     #  (KM,)  -->  (1, nlay)

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -35,6 +35,41 @@ def test_rrtm_creation():
 
 @pytest.mark.compiled
 @pytest.mark.fast
+def test_rrtm_aerosols():
+    from climlab.radiation.rrtm.rrtmg_lw import nbndlw
+    from climlab.radiation.rrtm.rrtmg_sw import nbndsw
+    # single column version
+    state = climlab.column_state(num_lev=num_lev)
+    #  these value are meaningless, just testing dimensions and making sure code runs
+    tauaer_lw = np.zeros((nbndlw,num_lev)) + 0.1
+    tauaer_sw = np.zeros((nbndsw,num_lev)) + 0.1
+    ssaaer_sw = np.zeros((nbndsw,num_lev)) + 0.1
+    asmaer_sw = np.zeros((nbndsw,num_lev)) + 0.1
+    rad = climlab.radiation.RRTMG(state=state, iaer_sw=10, 
+                                  tauaer_lw=tauaer_lw,
+                                  tauaer_sw=tauaer_sw,
+                                  ssaaer_sw=ssaaer_sw,
+                                  asmaer_sw=asmaer_sw)
+    #  Is the aerosol flag passed through appropriately?
+    assert rad.subprocess['SW'].iaer==10
+    #  Can we step forward?
+    rad.step_forward()
+    # 2D version
+    num_lat = 4
+    state = climlab.column_state(num_lat=num_lat, num_lev=num_lev)
+    tauaer_lw = np.zeros((nbndlw,num_lat,num_lev)) + 0.1
+    tauaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
+    ssaaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
+    asmaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
+    rad = climlab.radiation.RRTMG(state=state, iaer_sw=10, 
+                                  tauaer_lw=tauaer_lw,
+                                  tauaer_sw=tauaer_sw,
+                                  ssaaer_sw=ssaaer_sw,
+                                  asmaer_sw=asmaer_sw)
+    rad.step_forward()
+
+@pytest.mark.compiled
+@pytest.mark.fast
 def test_swap_component():
     # initial state (temperatures)
     state = climlab.column_state(num_lev=num_lev, num_lat=1, water_depth=5.)

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -47,12 +47,12 @@ def test_rrtm_aerosols():
     asmaer_sw = np.zeros((nbndsw,num_lev)) + 0.1
     ecaer_sw = np.zeros((naerec,num_lev)) + 0.1
     # ECMWF aerosols
-    rad = climlab.radiation.RRTMG(state=state, iaer_sw=6, ecaer_sw=ecaer_sw)
+    rad = climlab.radiation.RRTMG(state=state, iaer=6, ecaer_sw=ecaer_sw)
     #  Is the aerosol flag passed through appropriately?
     assert rad.subprocess['SW'].iaer==6
     rad.step_forward()
     # Full aerosols
-    rad = climlab.radiation.RRTMG(state=state, iaer_sw=10, 
+    rad = climlab.radiation.RRTMG(state=state, iaer=10, 
                                   tauaer_lw=tauaer_lw,
                                   tauaer_sw=tauaer_sw,
                                   ssaaer_sw=ssaaer_sw,
@@ -69,9 +69,9 @@ def test_rrtm_aerosols():
     ssaaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
     asmaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
     ecaer_sw = np.zeros((naerec,num_lat,num_lev)) + 0.1
-    rad = climlab.radiation.RRTMG(state=state, iaer_sw=6, ecaer_sw=ecaer_sw)
+    rad = climlab.radiation.RRTMG(state=state, iaer=6, ecaer_sw=ecaer_sw)
     rad.step_forward()
-    rad = climlab.radiation.RRTMG(state=state, iaer_sw=10, 
+    rad = climlab.radiation.RRTMG(state=state, iaer=10, 
                                   tauaer_lw=tauaer_lw,
                                   tauaer_sw=tauaer_sw,
                                   ssaaer_sw=ssaaer_sw,

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -37,7 +37,7 @@ def test_rrtm_creation():
 @pytest.mark.fast
 def test_rrtm_aerosols():
     from climlab.radiation.rrtm.rrtmg_lw import nbndlw
-    from climlab.radiation.rrtm.rrtmg_sw import nbndsw
+    from climlab.radiation.rrtm.rrtmg_sw import nbndsw, naerec
     # single column version
     state = climlab.column_state(num_lev=num_lev)
     #  these value are meaningless, just testing dimensions and making sure code runs
@@ -45,6 +45,13 @@ def test_rrtm_aerosols():
     tauaer_sw = np.zeros((nbndsw,num_lev)) + 0.1
     ssaaer_sw = np.zeros((nbndsw,num_lev)) + 0.1
     asmaer_sw = np.zeros((nbndsw,num_lev)) + 0.1
+    ecaer_sw = np.zeros((naerec,num_lev)) + 0.1
+    # ECMWF aerosols
+    rad = climlab.radiation.RRTMG(state=state, iaer_sw=6, ecaer_sw=ecaer_sw)
+    #  Is the aerosol flag passed through appropriately?
+    assert rad.subprocess['SW'].iaer==6
+    rad.step_forward()
+    # Full aerosols
     rad = climlab.radiation.RRTMG(state=state, iaer_sw=10, 
                                   tauaer_lw=tauaer_lw,
                                   tauaer_sw=tauaer_sw,
@@ -61,6 +68,9 @@ def test_rrtm_aerosols():
     tauaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
     ssaaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
     asmaer_sw = np.zeros((nbndsw,num_lat,num_lev)) + 0.1
+    ecaer_sw = np.zeros((naerec,num_lat,num_lev)) + 0.1
+    rad = climlab.radiation.RRTMG(state=state, iaer_sw=6, ecaer_sw=ecaer_sw)
+    rad.step_forward()
     rad = climlab.radiation.RRTMG(state=state, iaer_sw=10, 
                                   tauaer_lw=tauaer_lw,
                                   tauaer_sw=tauaer_sw,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools, os
 
-VERSION = '0.8.2'
+VERSION = '0.8.3.dev0'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,


### PR DESCRIPTION
Working on fully supporting aerosols in the climlab interface for RRTMG radiation.

This PR (work in progress) will address #195 and #79. It will be possible to pass aerosol optical properties through to RRTMG_SW and RRTMG_LW with the correct dimensionality for both single column and 2D (usually latitude-pressure) grids.

Full support for 3D grids with RRTMG is still not there, as discussed in https://github.com/climlab/climlab/issues/86