### PR TITLE
Set nopython=True for Numba

### DIFF
--- a/climlab/convection/akmaev_adjustment.py
+++ b/climlab/convection/akmaev_adjustment.py
@@ -139,6 +139,6 @@ def Akmaev_adjustment(theta, q, beta, n_k, theta_k, s_k, t_k):
 #   in pure Python. Results should be identical
 try:
     from numba import jit
-    Akmaev_adjustment = jit(signature_or_function=Akmaev_adjustment)
+    Akmaev_adjustment = jit(signature_or_function=Akmaev_adjustment, nopython=True)
 except ImportError:
     pass


### PR DESCRIPTION
Closes #200

Following [advice in the Numba docs](https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit), this PR explicitly sets `nopython=True` in the call to `numba.jit`.

There's no advantage to the old fall-back mode anyway. The jit call is wrapped in a `try...except` block already so if compilation fails for some reason, we fall back to pure python.

This makes some annoying deprecation notices go away.