### PR TITLE
SW aerosol table roll bug fix

### DIFF
--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -28,7 +28,6 @@ wavenum_bounds = np.array([820., 2600., 3250., 4000., 4650., 5150., 6150., 7700.
 wavenum_delta = np.diff(wavenum_bounds)
 # For some reason the band 820 - 2600 cm-1 is the last element in RRTMG_SW (Band 29) 
 # instead of first element (Band 16)
-# Climlab will keep bands in numerical order by wavenumber and reorder before passing to RRTMG_SW
 
 class RRTMG_SW(_Radiation_SW):
     def __init__(self,
@@ -179,11 +178,11 @@ class RRTMG_SW(_Radiation_SW):
         # In-cloud forward scattering fraction (delta function pointing forward "forward peaked scattering")
         fsfc = _climlab_to_rrtm(self.fsfc * np.ones_like(self.Tatm)) * np.ones([nbndsw,ncol,nlay])
         # Aerosol optical depth (iaer=10 only), (ncol,nlay,nbndsw)] #  (non-delta scaled)
-        tauaer = _climlab_to_rrtm(self.tauaer, spectral_axis=True, reorder_sw_bands=True)
+        tauaer = _climlab_to_rrtm(self.tauaer, spectral_axis=True)
         # Aerosol single scattering albedo (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
-        ssaaer = _climlab_to_rrtm(self.ssaaer, spectral_axis=True, reorder_sw_bands=True)
+        ssaaer = _climlab_to_rrtm(self.ssaaer, spectral_axis=True)
         # Aerosol asymmetry parameter (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
-        asmaer = _climlab_to_rrtm(self.asmaer, spectral_axis=True, reorder_sw_bands=True)
+        asmaer = _climlab_to_rrtm(self.asmaer, spectral_axis=True)
         # Aerosol optical depth at 0.55 micron (iaer=6 only), Dimensions,  (ncol,nlay,naerec)] #  (non-delta scaled)
         ecaer = _climlab_to_rrtm(self.ecaer, spectral_axis=True)
 

--- a/climlab/radiation/rrtm/utils.py
+++ b/climlab/radiation/rrtm/utils.py
@@ -51,7 +51,7 @@ def interface_temperature(Ts, Tatm, **kwargs):
     Tinterp = np.concatenate((Ttoa[..., np.newaxis], Tinterp, Ts), axis=-1)
     return Tinterp
 
-def _climlab_to_rrtm(field, spectral_axis=False, reorder_sw_bands=False):
+def _climlab_to_rrtm(field, spectral_axis=False, do_lev_flip=True):
     '''Prepare field with proper dimension order.
     RRTM code expects arrays with (ncol, nlay)
     and with pressure decreasing from surface at element 0
@@ -65,12 +65,11 @@ def _climlab_to_rrtm(field, spectral_axis=False, reorder_sw_bands=False):
 
     spectral_axis should be set to True if the field has an additional axis for spectral bands (nbndlw or nbndsw)
     
-    reorder_sw_bands should be set to True for shortwave fields with spectral bands to account for RRTMG_SW band ordering
-    (ignored if spectral_axis=False)
     '''
     try:
         #  Flip along the last axis to reverse the pressure order
-        field = field[..., ::-1]
+        if do_lev_flip:
+            field = field[..., ::-1]
     except:
         if np.isscalar(field):
             return field
@@ -89,8 +88,6 @@ def _climlab_to_rrtm(field, spectral_axis=False, reorder_sw_bands=False):
     #elif num_dims==3:  # (num_lat, num_lon, num_lev)
         #  Need to reshape this array
     if spectral_axis:
-        if reorder_sw_bands:
-            modfield = np.roll(modfield, -1, axis=0)  # Make Band 29 the last element of array
         # transpose to get [ncol,nlay,nbnd]
         modfield = np.transpose(modfield, (1,2,0))
     return modfield


### PR DESCRIPTION
Climlab previously had a roll command over the optical tables of aerosols in SW. This was done to make the bands monotonically increasing, since that is not the case for the choice in rrtmg. However, this choice caused a bug when feeding a non-spectrally trivial table (which was painful to debug). So this line has been removed in this PR. Also, a flag was added to control flipping along the last axis (lev) to reverse the pressure order. The default is True, which is the same functionality as before, but now one can control it externally.