### PR TITLE
adding support for time-averaging in xarray exporting of diagnostics

### DIFF
--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -502,7 +502,7 @@ class Process(object):
         except:
             print('No diagnostic named {} was found.'.format(name))
 
-    def to_xarray(self, diagnostics=False):
+    def to_xarray(self, diagnostics=False, timeave=False):
         """ Convert process variables to ``xarray.Dataset`` format.
 
         With ``diagnostics=True``, both state and diagnostic variables are included.
@@ -575,7 +575,11 @@ class Process(object):
                     TdotSW_clr        (lev) float64 2.821 0.5123 0.3936 0.3368 0.3174 0.3299 ...
 
         """
-        if diagnostics:
+        if timeave and hasattr(self, 'timeave'):
+            dic = self.state.copy()
+            dic.update(self.timeave)
+            return state_to_xarray(dic)
+        elif diagnostics:
             dic = self.state.copy()
             dic.update(self.diagnostics)
             return state_to_xarray(dic)

--- a/climlab/tests/xarray_test.py
+++ b/climlab/tests/xarray_test.py
@@ -5,6 +5,7 @@ import climlab
 def to_xarray(model):
     model.to_xarray()
     model.to_xarray(diagnostics=True)
+    model.to_xarray(timeave=True)
     if hasattr(model, 'timeave'):
         climlab.to_xarray(model.timeave)
     # We should be able to render all tendencies as xarray


### PR DESCRIPTION
In this feature, when one calls model.to_xarray(timeave=True), the output would be the time-averaged diagnostics and not the instantaneous values. The default value for timeave is False, and in such a case the original functionality is kept unchanged.