### PR TITLE
mse diff. and q diff. adv. implementation.

### DIFF
--- a/climlab/dynamics/meridional_moist_diffusion.py
+++ b/climlab/dynamics/meridional_moist_diffusion.py
@@ -121,7 +121,9 @@ import numpy as np
 from .meridional_heat_diffusion import MeridionalHeatDiffusion
 from climlab.utils.thermo import qsat
 from climlab import constants as const
-
+from climlab.process.time_dependent_process import TimeDependentProcess
+from climlab.process.diagnostic import DiagnosticProcess
+from .meridional_advection_diffusion import MeridionalAdvectionDiffusion, MeridionalDiffusion
 
 class MeridionalMoistDiffusion(MeridionalHeatDiffusion):
     def __init__(self, D=0.24, relative_humidity=0.8, **kwargs):
@@ -131,7 +133,8 @@ class MeridionalMoistDiffusion(MeridionalHeatDiffusion):
 
     def _update_diffusivity(self):
         Tinterp = np.interp(self.lat_bounds, self.lat, np.squeeze(self.Ts))
-        Tkelvin = Tinterp + const.tempCtoK
+        is_kelvin = np.mean(Tinterp) > 140.0
+        Tkelvin = Tinterp if is_kelvin else Tinterp + const.tempCtoK
         f = moist_amplification_factor(Tkelvin, self.relative_humidity)
         heat_capacity = self.Ts.domain.heat_capacity
         self.K = self.D / heat_capacity * const.a**2 * (1+f)
@@ -141,11 +144,80 @@ class MeridionalMoistDiffusion(MeridionalHeatDiffusion):
         #  and then do all the same stuff the parent class would do...
         return super(MeridionalMoistDiffusion, self)._implicit_solver()
 
+class MeridionalMoistDiffusionAtm(MeridionalHeatDiffusion):
+    def __init__(self, D=0.24, relative_humidity=0.8, do_moist_fac=True, **kwargs):
+        self.relative_humidity = relative_humidity
+        self.do_moist_fac = do_moist_fac
+        super(MeridionalMoistDiffusionAtm, self).__init__(D=D, **kwargs)
+        self._update_diffusivity()
 
-def moist_amplification_factor(Tkelvin, relative_humidity=0.8):
+    def _update_diffusivity(self):
+        lat_bounds = self.lat_bounds
+        n_lev = self.Tatm.domain.lev.num_points
+        n_lat = self.Tatm.domain.lat.num_points
+        lat = self.Tatm.domain.lat.points
+        lev = self.Tatm.domain.lev.points[np.newaxis,:]
+        is_kelvin = np.mean(self.Tatm) > 140.0
+        dT = 0.0 if is_kelvin else const.tempCtoK
+        Tkelvin = self.Tatm + dT
+        if self.do_moist_fac:
+            m_amp_fac = moist_amplification_factor(Tkelvin, self.relative_humidity, p=lev, do_simplified=True)
+        else:
+            m_amp_fac = np.zeros_like(Tkelvin)
+        heat_capacity = self.Tatm.domain.heat_capacity[np.newaxis,:]
+        K_fac = const.a**2 * (1.0 + m_amp_fac) / heat_capacity
+        K_fac_interp = np.zeros((n_lev, n_lat+1))
+        for k in range(n_lev):
+            K_fac_interp[k,:] = np.interp(lat_bounds, lat, K_fac[:,k])
+        self.K = self.D * K_fac_interp
+
+    def _implicit_solver(self):
+        self._update_diffusivity()
+        #  and then do all the same stuff the parent class would do...
+        return super(MeridionalMoistDiffusionAtm, self)._implicit_solver()
+
+def moist_amplification_factor(Tkelvin, relative_humidity=0.8, p=1000.0, deltaT = 0.01, do_simplified=False):
     '''Compute the moisture amplification factor for the moist diffusivity
     given relative humidity and reference temperature profile.'''
-    deltaT = 0.01
     #  slope of saturation specific humidity at 1000 hPa
-    dqsdTs = (qsat(Tkelvin+deltaT/2, 1000.) - qsat(Tkelvin-deltaT/2, 1000.)) / deltaT
+    dqsdTs = (qsat(Tkelvin+deltaT/2, p, do_simplified=do_simplified) - qsat(Tkelvin-deltaT/2, p, do_simplified=do_simplified)) / deltaT
     return const.Lhvap / const.cp * relative_humidity * dqsdTs
+
+class MoistStaticEnergy(DiagnosticProcess):
+    def __init__(self, **kwargs):
+        super(MoistStaticEnergy, self).__init__(**kwargs)
+        assert hasattr(self.state, 'q'), 'q must be a state parameter when using MoistStaticEnergy'
+        assert hasattr(self.state, 'Tatm'), 'Tatm must be a state parameter when using MoistStaticEnergy'
+        self._mse = 0.0 * self.Tatm
+        self._compute_mse()
+
+    def _compute_mse(self):
+        self._mse[:] = const.cp * self.Tatm + const.Lhvap * self.q
+
+    def get_T_part(self, mse_part, q_part):
+        return (mse_part - const.Lhvap * q_part) / const.cp
+
+    @property
+    def mse(self):
+        self._compute_mse()
+        return self._mse
+    
+class MoistMeridionalAdvectionDiffusion(TimeDependentProcess):
+    def __init__(self, K=0., Kq=0., Uq=0., **kwargs):
+        super(MoistMeridionalAdvectionDiffusion, self).__init__(**kwargs)
+        assert hasattr(self.state, 'q'), 'q must be a state parameter when using MoistMeridionalAdvectionDiffusion'
+        assert hasattr(self.state, 'Tatm'), 'Tatm must be a state parameter when using MoistMeridionalAdvectionDiffusion'
+        self.mse_obj = MoistStaticEnergy(state=self.state)
+        self.diff_q = MeridionalAdvectionDiffusion(name='q Diffusion',
+                            state = {'q': self.state['q']},
+                            K=Kq, U=Uq, timestep=self.timestep)
+        self.diff_mse = MeridionalDiffusion(name='MSE Diffusion',
+                            state = {'mse': self.mse_obj.mse},
+                            K=K, timestep=self.timestep)
+
+    def _compute(self):
+        self.mse_obj._compute_mse()
+        dict_q = self.diff_q._compute()
+        dict_mse = self.diff_mse._compute()
+        dict_t = {'Tatm': self.mse_obj.get_T_part(dict_mse['mse'], dict_q['q'])}
+        return {'q': dict_q['q'], 'Tatm': dict_t['Tatm']}

--- a/climlab/utils/thermo.py
+++ b/climlab/utils/thermo.py
@@ -53,16 +53,20 @@ def clausius_clapeyron(T):
     es = 6.112 * exp(17.67*Tcel/(Tcel+243.5))
     return es
 
-def qsat(T,p):
+def qsat(T,p, do_simplified=False):
     """Compute saturation specific humidity as function of temperature and pressure.
 
     Input:  T is temperature in Kelvin
             p is pressure in hPa or mb
     Output: saturation specific humidity (dimensionless).
 
+    do_simplified removes the (1-eps)*es term in the denominator, to avoid divergence at low altitudes
     """
     es = clausius_clapeyron(T)
-    q = eps * es / (p - (1 - eps) * es )
+    if do_simplified:
+        q = eps * es / p
+    else:
+        q = eps * es / (p - (1 - eps) * es )
     return q
 
 def virtual_temperature_from_mixing_ratio(T,w):


### PR DESCRIPTION
This PR touches on 3 topics:
1. Adds a units test for the temperature used in MeridionalMoistDiffusion, to avoid a bug due to unit mismatch (C vs K).
2. Adding a version of MeridionalMoistDiffusion for atmospheric temperature (assuming fixed relative humidity)
3. The most significant change - MoistMeridionalAdvectionDiffusion: adding a "diagonal" treatment of pure meridional diffusive process for the moist static energy and a mixture of meridional diffusion and advection for the specific humidity. 

A test wasn't added yet, since I wasn't able to come up with a good and simple example that will exemplify and test the benefits and features of this approach.