### PR TITLE
New Limiter process that implements min/max bounds for state variables

### DIFF
--- a/climlab/process/__init__.py
+++ b/climlab/process/__init__.py
@@ -6,3 +6,4 @@ from .implicit import ImplicitProcess
 from .diagnostic import DiagnosticProcess
 from .energy_budget import EnergyBudget
 from .external_forcing import ExternalForcing
+from .limiter import Limiter

--- a/climlab/process/limiter.py
+++ b/climlab/process/limiter.py
@@ -1,0 +1,64 @@
+import numpy as np
+from climlab.process import TimeDependentProcess
+
+
+class Limiter(TimeDependentProcess):
+    '''A process that implements strict bounds on the allowable range of values of state variables.
+    Values outside the given bounds are adjusted back to the bounding value at each timestep.
+
+    Bounding values are stored in a dictionary ``.bounds`` which has identical keys to ``.state``
+
+    Each item in the ``.bounds`` dict is another dict containing the keys ``'minimum'`` and ``'maximum'``.
+    By default these are initialized to ``None`` and ``np.inf`` respectively,
+    which means the process produces zero adjustment.
+
+    The user needs to specify desired minimum and/or maximum values for each state variable.
+    These can be specified at process creation time using the keyword argument ``bounds``, 
+    or modified in-place (see example below).
+
+    For diagnostic purposes, we can always access the adjustments (in state variable units) 
+    and the tendencies (in state variable units per second) produced by the Limiter
+    just like any other process (see example below) 
+
+    Example use: an EBM with surface temperature limited to <= 25 degrees C::
+
+        import climlab
+        ebm = climlab.EBM()
+        #  Create the Limiter process, and make sure it has a matching timestep
+        mylimiter = climlab.process.Limiter(state=ebm.state, timestep=ebm.timestep)
+        #  Now set our desired upper bound on the temperature
+        mylimiter.bounds['Ts']['maximum'] = 25.
+        #  And couple it to the rest of the model
+        ebm.add_subprocess('TempLimiter', mylimiter)
+        #  Take a step forward and verify that surface temperatures do not exceed 25 degrees C
+        ebm.step_forward()
+        assert np.all(ebm.Ts<=25)
+        #  Examine the tendencies (in degrees C / second) produced by the Limiter:
+        #  They should be zero everywhere the temperaure is less than 25 degrees: 
+        print(ebm.subprocess['TempLimiter'].tendencies)
+    '''
+    def __init__(self, bounds={}, **kwargs):
+        super(Limiter, self).__init__(**kwargs)
+        #  Initialize bounds for all state variables. `None` means no bounds
+        #  By default the process should produce zero adjustment
+        #  Note that in numpy 2.0 and above, we can do this by setting `None` on both bounds
+        #  But in numpy < 2.0 that's not allowed, so we use `np.inf` as upper bound instead
+        self.bounds = {}
+        for name in self.state:
+            self.bounds[name] = {'minimum': None, 'maximum': np.inf}
+        #  Now override with any user-specified values
+        for name, thisbounddict in bounds.items():
+            if 'minimum' in thisbounddict:
+                self.bounds[name]['minimum'] = thisbounddict['minimum']
+            if 'maximum' in thisbounddict:
+                self.bounds[name]['maximum'] = thisbounddict['maximum']
+        self.time_type = 'adjustment'
+        self.adjustment = {}
+
+    def _compute(self):
+        for name, value in self.state.items():
+            min = self.bounds[name]['minimum']
+            max = self.bounds[name]['maximum']
+            clipped = np.clip(value, a_min=min, a_max=max)
+            self.adjustment[name] = clipped - value
+        return self.adjustment

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -137,12 +137,15 @@ def test_moist_EBM_creation():
 def test_bounded_EBM():
     '''Test adding a Limiter process that keeps the temperature bounded 
     with a specified range.'''
+    max = 25.
+    min = -4.
+    tol = 1E-10  # avoid failing the test due to some numerical issues with the clipping
     ebm = climlab.EBM()
     mylimiter = climlab.process.Limiter(state=ebm.state, timestep=ebm.timestep)
-    mylimiter.bounds['Ts']['maximum'] = 25.
+    mylimiter.bounds['Ts']['maximum'] = max
     ebm.add_subprocess('TempLimiter', mylimiter)
     ebm.step_forward()
-    assert np.all(ebm.Ts<=25)
-    mylimiter.bounds['Ts']['minimum'] = -4.
+    assert np.all(ebm.Ts<=(max+tol))
+    mylimiter.bounds['Ts']['minimum'] = min
     ebm.step_forward()
-    assert np.all(ebm.Ts>=-4)
+    assert np.all(np.array(ebm.Ts)>=(min-tol))

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -132,3 +132,17 @@ def test_moist_EBM_creation():
     m.add_subprocess('diffusion', diff)
     m.step_forward()
     assert hasattr(m, 'heat_transport')
+
+@pytest.mark.fast
+def test_bounded_EBM():
+    '''Test adding a Limiter process that keeps the temperature bounded 
+    with a specified range.'''
+    ebm = climlab.EBM()
+    mylimiter = climlab.process.Limiter(state=ebm.state, timestep=ebm.timestep)
+    mylimiter.bounds['Ts']['maximum'] = 25.
+    ebm.add_subprocess('TempLimiter', mylimiter)
+    ebm.step_forward()
+    assert np.all(ebm.Ts<=25)
+    mylimiter.bounds['Ts']['minimum'] = -4.
+    ebm.step_forward()
+    assert np.all(ebm.Ts>=-4)

--- a/docs/source/api/climlab.process.limiter.rst
+++ b/docs/source/api/climlab.process.limiter.rst
@@ -1,0 +1,12 @@
+limiter
+-------
+
+.. inheritance-diagram:: climlab.process.limiter
+   :parts: 1
+   :private-bases:
+
+.. automodule:: climlab.process.limiter
+    :members:
+    :undoc-members:
+    :private-members:
+    :show-inheritance:    

--- a/docs/source/api/climlab.process.rst
+++ b/docs/source/api/climlab.process.rst
@@ -16,3 +16,4 @@ climlab.process
    climlab.process.implicit
    climlab.process.process
    climlab.process.time_dependent_process
+   climlab.process.limiter


### PR DESCRIPTION
This PR introduces a new process class `climlab.process.Limiter()` that implements flexible minimum / maximum values for state variables. 

This process can be added as a subprocess to any model to specific minimum and/or maximum allowable values for state variables. It is implemented as an `adjustment` type of process. At every timestep, the necessary adjustment to keep state variables within the allowable range is computed and applied. The adjustment (and also the corresponding tendency per unit time) are stored as internal process attributes just like every other Process, and so available for diagnostic use.

Some basic testing and basic documentation are included.