### PR TITLE
Make same-named diagnostics additive

### DIFF
--- a/climlab/model/column.py
+++ b/climlab/model/column.py
@@ -101,7 +101,7 @@ class GreyRadiationModel(TimeDependentProcess):
                     'SW_down_TOA',
                     'planetary_albedo']
         for name in newdiags:
-            self.add_diagnostic(name)
+            self.add_diagnostic(name, 0. * self.Ts)
         # This process has to handle the coupling between
         # insolation and column radiation
         self.subprocess['SW'].flux_from_space = \
@@ -183,7 +183,7 @@ class BandRCModel(RadiativeConvectiveModel):
         # This process has to handle the coupling between
         # insolation and column radiation
         self.subprocess['SW'].flux_from_space = \
-            self.subprocess['insolation'].diagnostics['insolation']
+            self.subprocess['insolation'].insolation
 
 
 def compute_layer_absorptivity(abs_coeff, dp):

--- a/climlab/model/column.py
+++ b/climlab/model/column.py
@@ -158,18 +158,13 @@ class BandRCModel(RadiativeConvectiveModel):
         #  Initialize specific humidity
         h2o = ManabeWaterVapor(state=self.state, **self.param)
         self.add_subprocess('H2O', h2o)
-        # q is an input field for this process, which is set by subproc
-        #  (though in this sense it is actually diagnostic...)
-        newinput = ['q']
-        self.add_input('q')
-        self.q = self.subprocess['H2O'].q
 
         #  initialize radiatively active gas inventories
         self.absorber_vmr = {}
         self.absorber_vmr['CO2'] = 380.E-6 * np.ones_like(self.Tatm)
         self.absorber_vmr['O3'] = np.zeros_like(self.Tatm)
         # water vapor is actually specific humidity, not VMR.
-        self.absorber_vmr['H2O'] = self.q
+        self.absorber_vmr['H2O'] = h2o.q
 
         longwave = FourBandLW(state=self.state,
                               absorber_vmr=self.absorber_vmr,

--- a/climlab/model/column.py
+++ b/climlab/model/column.py
@@ -37,14 +37,11 @@ calculated for 45N.
 from __future__ import division
 import numpy as np
 from climlab import constants as const
-from climlab.process.time_dependent_process import TimeDependentProcess
-from climlab.domain.initial import column_state
-from climlab.domain.field import Field
-from climlab.radiation.insolation import FixedInsolation
-from climlab.radiation.greygas import GreyGas, GreyGasSW
-from climlab.convection.convadj import ConvectiveAdjustment
-from climlab.radiation.nband import ThreeBandSW, FourBandLW, FourBandSW
-from climlab.radiation.water_vapor import ManabeWaterVapor
+from climlab.process import TimeDependentProcess
+from climlab.domain import column_state, Field
+from climlab.radiation import (FixedInsolation, GreyGas, GreyGasSW,
+        ThreeBandSW, FourBandLW, ManabeWaterVapor)
+from climlab.convection import ConvectiveAdjustment
 
 class GreyRadiationModel(TimeDependentProcess):
     def __init__(self,

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -273,11 +273,9 @@ class Process(object):
             self.subprocess.update({name: proc})
             self.has_process_type_list = False
             # Add subprocess diagnostics to parent
-            #  (if there are no name conflicts)
+            #  (same-named diagnostics are assumed to be additive)
             for diagname, value in proc.diagnostics.items():
-                #if not (diagname in self.diagnostics or hasattr(self, diagname)):
-                #    self.add_diagnostic(diagname, value)
-                self.add_diagnostic(diagname, value)
+                self.add_diagnostic(diagname, 0.*value)
         else:
             raise ValueError('subprocess must be Process object')
 

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -246,7 +246,8 @@ class TimeDependentProcess(Process):
         #  Now accumulate additive diagnostics from subprocesses
         for procname, proc in self.subprocess.items():
             for diagname, value in proc.diagnostics.items():
-                self.__dict__[diagname] += value
+                if self.__dict__[diagname].shape == value.shape:
+                    self.__dict__[diagname] += value
         return self.tendencies
 
     def _compute_type(self, proctype):

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -206,6 +206,9 @@ class TimeDependentProcess(Process):
         #  First reset tendencies to zero -- recomputing them is the point of this method
         for varname in self.tendencies:
             self.tendencies[varname] *= 0.
+        #  Also reset all diagnostics to zero -- they will be accumulated from subprocesses
+        for diagname, diag in self.diagnostics.items():
+            diag *= 0.
         if not self.has_process_type_list:
             self._build_process_type_list()
         tendencies = {}
@@ -240,6 +243,10 @@ class TimeDependentProcess(Process):
                 self_tend[varname] /= self.timestep
         for varname, tend in self_tend.items():
             self.tendencies[varname] += tend
+        #  Now accumulate additive diagnostics from subprocesses
+        for procname, proc in self.subprocess.items():
+            for diagname, value in proc.diagnostics.items():
+                self.__dict__[diagname] += value
         return self.tendencies
 
     def _compute_type(self, proctype):
@@ -265,8 +272,9 @@ class TimeDependentProcess(Process):
                 tenddict = proc.tendencies
             for name, tend in tenddict.items():
                 tendencies[name] += tend
-            for diagname, value in proc.diagnostics.items():
-                self.__setattr__(diagname, value)
+            # for diagname, value in proc.diagnostics.items():
+            #     #  additive diagnostics...
+            #     self.__setattr__(diagname, value)
         return tendencies
 
     def _compute(self):

--- a/climlab/radiation/__init__.py
+++ b/climlab/radiation/__init__.py
@@ -9,7 +9,7 @@ from .absorbed_shorwave import SimpleAbsorbedShortwave
 from .boltzmann import Boltzmann
 from .greygas import GreyGas, GreyGasSW
 from .insolation import FixedInsolation, P2Insolation, AnnualMeanInsolation, DailyInsolation, InstantInsolation
-from .nband import NbandRadiation, ThreeBandSW
+from .nband import NbandRadiation, ThreeBandSW, FourBandLW, FourBandSW
 from .water_vapor import ManabeWaterVapor
 #from radiation import Radiation, Radiation_SW, Radiation_LW
 from .cam3 import CAM3, CAM3_LW, CAM3_SW

--- a/climlab/radiation/greygas.py
+++ b/climlab/radiation/greygas.py
@@ -63,7 +63,7 @@ class GreyGas(EnergyBudget):
         #  Initialize diagnostics
         self.add_diagnostic('emission', 0. * self.Tatm)
         self.add_diagnostic('emission_sfc', 0. * self.Ts)
-        self.add_diagnostic('flux_reflected_up')
+        # self.add_diagnostic('flux_reflected_up', 0. * self.Ts) 
 
     @property
     def absorptivity(self):
@@ -142,7 +142,7 @@ class GreyGas(EnergyBudget):
         self.flux_net = self.flux_up - self.flux_down
         # absorbed radiation (flux convergence) in W / m**2 (per band)
         self.absorbed = np.diff(self.flux_net, axis=-1)
-        self.absorbed_total = np.sum(self.absorbed, axis=-1)
+        self.absorbed_total = np.sum(self.absorbed, axis=-1, keepdims=True) 
         self.flux_to_space = self._compute_flux_top()
 
     def _compute_flux_top(self):

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -130,7 +130,7 @@ class _Insolation(DiagnosticProcess):
         pass
 
     def _get_current_insolation(self):
-        pass
+        self._compute_fixed()
 
     def _compute(self):
         self._get_current_insolation()

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -19,8 +19,7 @@ At least two diagnostics are provided:
 from __future__ import division
 import numpy as np
 from climlab.process.diagnostic import DiagnosticProcess
-from climlab.domain.field import Field
-from climlab.domain.field import to_latlon
+from climlab.domain.field import Field, to_latlon
 from climlab.utils.legendre import P2
 from climlab import constants as const
 from climlab.solar.insolation import daily_insolation, instant_insolation

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -83,15 +83,12 @@ class _Insolation(DiagnosticProcess):
     def __init__(self, S0=const.S0, **kwargs):
         super(_Insolation, self).__init__(**kwargs)
         #  initialize diagnostics with correct shape
-        self.add_diagnostic('insolation')
-        self.add_diagnostic('coszen')
         try:
             domain = self.domains['sfc']
         except:
             domain = self.domains['default']
-        self.insolation = Field(np.zeros(domain.shape), domain=domain)
-        self.coszen = Field(np.zeros(domain.shape), domain=domain)
-        self.declare_diagnostics(['insolation','coszen'])
+        self.add_diagnostic('insolation', Field(np.zeros(domain.shape), domain=domain))
+        self.add_diagnostic('coszen', Field(np.zeros(domain.shape), domain=domain))
         self.S0 = S0
         #  Now that we have a value for self.S0 we can compute the correct coszen
         self.coszen = self._coszen_from_insolation()

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -122,8 +122,8 @@ class P2Albedo(DiagnosticProcess):
         super(P2Albedo, self).__init__(**kwargs)
         self.a0 = a0
         self.a2 = a2
-        self.add_diagnostic('albedo')
         self._compute_fixed()
+        self.add_diagnostic('albedo', self._albedo.copy())
 
     @property
     def a0(self):
@@ -178,7 +178,6 @@ class P2Albedo(DiagnosticProcess):
         # make sure that the diagnostic has the correct field dimensions.
         dom = next(iter(self.domains.values()))
         self._albedo = Field(albedo, domain=dom)
-        self.albedo = self._albedo.copy()
 
     def _compute(self):
         self.albedo[:] = self._albedo
@@ -218,8 +217,8 @@ class Iceline(DiagnosticProcess):
     def __init__(self, Tf=-10., **kwargs):
         super(Iceline, self).__init__(**kwargs)
         self.param['Tf'] = Tf
-        self.add_diagnostic('icelat')
-        self.add_diagnostic('ice_area')
+        self.add_diagnostic('icelat', np.array([-90., 90.]))
+        self.add_diagnostic('ice_area', np.array(0.))
         #  Set diagnostics based on initial conditions
         self.find_icelines()
 

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -42,31 +42,20 @@ class ConstantAlbedo(DiagnosticProcess):
     def __init__(self, albedo=0.33, **kwargs):
         '''Uniform prescribed albedo.'''
         super(ConstantAlbedo, self).__init__(**kwargs)
-        dom = next(iter(self.domains.values()))
-        self.add_diagnostic('albedo', Field(albedo, domain=dom))
-        #self.albedo = albedo
+        self.add_diagnostic('albedo', albedo)
 
-    # @property
-    # def albedo(self):
-    #     """Property of albedo value.
-    #
-    #     :getter:    Returns the albedo value which is stored in diagnostic dict
-    #                 ``self.diagnostic['albedo']``
-    #     :setter:    * sets albedo which is addressed as ``diagnostics['albedo']``
-    #                   to the new value through creating a Field on the basis
-    #                   of domain ``self.domain['default']``
-    #                 * updates the parameter dictionary ``self.param['albedo']``
-    #     :type:      Field
-    #
-    #     """
-    #     return self.diagnostics['albedo']
-    # @albedo.setter
-    # def albedo(self, value):
-    #     #dom = self.domains['default']
-    #     #  this is a more robust way to get the single value from dictionary:
-    #     dom = self.domains.itervalues().next()
-    #     self.diagnostics['albedo'] = Field(value, domain=dom)
-    #     self.param['albedo'] = value
+    @property
+    def albedo(self):
+        return self._albedo
+    @albedo.setter
+    def albedo(self, value):
+        dom = next(iter(self.domains.values()))
+        self._albedo = Field(value, domain=dom)
+        self.param['albedo'] = value
+
+    def _compute(self):
+        self.albedo[:] = self.param['albedo']
+        return {}
 
 
 class P2Albedo(DiagnosticProcess):
@@ -129,7 +118,6 @@ class P2Albedo(DiagnosticProcess):
 
 
     """
-
     def __init__(self, a0=0.33, a2=0.25, **kwargs):
         super(P2Albedo, self).__init__(**kwargs)
         self.a0 = a0
@@ -188,11 +176,13 @@ class P2Albedo(DiagnosticProcess):
         except:
             albedo = np.zeros_like(phi)
         # make sure that the diagnostic has the correct field dimensions.
-        #dom = self.domains['default']
-        #  this is a more robust way to get the single value from dictionary:
         dom = next(iter(self.domains.values()))
-        self.albedo = Field(albedo, domain=dom)
+        self._albedo = Field(albedo, domain=dom)
+        self.albedo = self._albedo.copy()
 
+    def _compute(self):
+        self.albedo[:] = self._albedo
+        return {}
 
 
 class Iceline(DiagnosticProcess):

--- a/climlab/tests/test_grey_radiation.py
+++ b/climlab/tests/test_grey_radiation.py
@@ -94,3 +94,17 @@ def test_external_tendency():
     model2.step_forward()
     assert model.tendencies['Tatm'] + temp_tend == pytest.approx(model2.tendencies['Tatm'])
     #assert np.all(np.isclose(model.tendencies['Tatm'] == (model2.tendencies['Tatm']-temp_tend))
+
+@pytest.mark.fast
+def test_additive_diagnostics(model):
+    """Check to see that diagnostics in parent process are the sum of 
+    same-named diagnostics in subprocesses."""
+    model.step_forward()
+    for diagname in ['flux_from_sfc',
+                 'flux_to_sfc',
+                 'flux_to_space',
+                 'absorbed',
+                 'absorbed_total']:
+        assert np.all(model.diagnostics[diagname] == 
+            model.subprocess['SW'].diagnostics[diagname] 
+            + model.subprocess['LW'].diagnostics[diagname])


### PR DESCRIPTION
This PR addresses #202 

We will now assume that diagnostics produced by subprocesses that share a name are intended to be additive with each other. This assumes that they share the same unit, and the values are not tilmestep-dependent (e.g. they represent changes per unit time rather than time-integrated values).

Implementation requires some changes in the logic for how diagnostics are handled, which has been a bit of a mess.