### PR TITLE
Diagnostics improvements for GreyGas model

### DIFF
--- a/climlab/model/__init__.py
+++ b/climlab/model/__init__.py
@@ -25,3 +25,5 @@ as subprocesses of a parent process.
 See the documentation for the RRTMG scheme for an example of building a
 radiative-convective column model from individual components.
 '''
+from .column import GreyRadiationModel, RadiativeConvectiveModel, BandRCModel
+from .ebm import EBM, EBM_annual, EBM_seasonal

--- a/climlab/radiation/greygas.py
+++ b/climlab/radiation/greygas.py
@@ -134,16 +134,16 @@ class GreyGas(EnergyBudget):
         self.flux_down = self.trans.flux_down(fromspace, self.emission)
         self.flux_reflected_up = self.trans.flux_reflected_up(self.flux_down, self.albedo_sfc)
         # this ensure same dimensions as other fields
-        self.flux_to_sfc = self.flux_down[..., -1, np.newaxis]
-        self.flux_from_sfc = (self.emission_sfc +
+        self.flux_to_sfc[:] = self.flux_down[..., -1, np.newaxis]
+        self.flux_from_sfc[:] = (self.emission_sfc +
                               self.flux_reflected_up[..., -1, np.newaxis])
         self.flux_up = self.trans.flux_up(self.flux_from_sfc,
                             self.emission + self.flux_reflected_up[...,0:-1])
         self.flux_net = self.flux_up - self.flux_down
         # absorbed radiation (flux convergence) in W / m**2 (per band)
-        self.absorbed = np.diff(self.flux_net, axis=-1)
-        self.absorbed_total = np.sum(self.absorbed, axis=-1, keepdims=True) 
-        self.flux_to_space = self._compute_flux_top()
+        self.absorbed[:] = np.diff(self.flux_net, axis=-1)
+        self.absorbed_total[:] = np.sum(self.absorbed, axis=-1, keepdims=True) 
+        self.flux_to_space[:] = self._compute_flux_top()
 
     def _compute_flux_top(self):
         bandflux = self.flux_up[..., 0, np.newaxis]


### PR DESCRIPTION
This PR further reduces warnings associated with attempts to convert `Field` variables into xarray format, addressing #220.

Along the way, I think this fixes an unreported bug in the diagnostics produced by `climlab.BandRCModel`. We need to sum over spectral bands to get valid diagnostics for things like ASR and OLR.

This PR also fixes an oversight in the namespace organization. Previously it was not possible to import things like
```
from climlab.model import EBM
```

That is now fixed. Related to #85 