### PR TITLE
Switch CI builds to use Miniforge

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,16 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python environment with Mambaforge
+      - name: Setup Python environment with Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}
           activate-environment: test_env
           channel-priority: strict
           environment-file: ${{ matrix.environment-file }}
-          use-mamba: true
 
       - name: Build and install climlab
         run: |


### PR DESCRIPTION
Mambaforge is now [deprecated](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/).

This PR switches the CI script to install Miniforge instead. Functionality should be identical but fewer warnings from GitHub Actions.