### PR TITLE
Cloud column randomness

### DIFF
--- a/climlab/radiation/radiation.py
+++ b/climlab/radiation/radiation.py
@@ -200,6 +200,9 @@ class _Radiation(EnergyBudget):
         self.add_input('ciwp', ciwp)
         self.add_input('r_liq', r_liq)
         self.add_input('r_ice', r_ice)
+        self.do_col_by_col = kwargs.get('do_col_by_col', False)
+        self.do_seed_permutation = kwargs.get('do_seed_permutation', False)
+        self.n_rrtmg_repeat = kwargs.get('n_rrtmg_repeat', 1)
 
 
 class _Radiation_SW(_Radiation):

--- a/climlab/radiation/rrtm/rrtmg_lw.py
+++ b/climlab/radiation/rrtm/rrtmg_lw.py
@@ -128,8 +128,7 @@ class RRTMG_LW(_Radiation_LW):
                 inflglw, iceflglw, liqflglw,
                 cldfrac, ciwp, clwp, reic, relq, tauc, tauaer,) = self._prepare_lw_arguments()
 
-        n_rrtmg_repeat = self.n_rrtmg_repeat if (icld == 0 and self.do_seed_permutation) else 1
-
+        n_rrtmg_repeat = self.n_rrtmg_repeat if (icld > 0 and self.do_seed_permutation) else 1
         for ind_rrtmg_call in range(n_rrtmg_repeat):
             if icld == 0:  # clear-sky only
                 cldfmcl = np.zeros((ngptlw,ncol,nlay))

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -209,7 +209,7 @@ class RRTMG_SW(_Radiation_SW):
          cldfrac, ciwp, clwp, reic, relq, tauc, ssac, asmc, fsfc,
          tauaer, ssaaer, asmaer, ecaer,) = self._prepare_sw_arguments()
 
-        n_rrtmg_repeat = self.n_rrtmg_repeat if (icld == 0 and self.do_seed_permutation) else 1
+        n_rrtmg_repeat = self.n_rrtmg_repeat if (icld > 0 and self.do_seed_permutation) else 1
         for ind_rrtmg_call in range(n_rrtmg_repeat):
             if icld == 0:  # clear-sky only
                 cldfmcl = np.zeros((ngptsw,ncol,nlay))

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -208,34 +208,79 @@ class RRTMG_SW(_Radiation_SW):
          inflgsw, iceflgsw, liqflgsw,
          cldfrac, ciwp, clwp, reic, relq, tauc, ssac, asmc, fsfc,
          tauaer, ssaaer, asmaer, ecaer,) = self._prepare_sw_arguments()
-        if icld == 0:  # clear-sky only
-            cldfmcl = np.zeros((ngptsw,ncol,nlay))
-            ciwpmcl = np.zeros((ngptsw,ncol,nlay))
-            clwpmcl = np.zeros((ngptsw,ncol,nlay))
-            reicmcl = np.zeros((ncol,nlay))
-            relqmcl = np.zeros((ncol,nlay))
-            taucmcl = np.zeros((ngptsw,ncol,nlay))
-            ssacmcl = np.zeros((ngptsw,ncol,nlay))
-            asmcmcl = np.zeros((ngptsw,ncol,nlay))
-            fsfcmcl = np.zeros((ngptsw,ncol,nlay))
-        else:
-            #  Call the Monte Carlo Independent Column Approximation (McICA, Pincus et al., JC, 2003)
-            (cldfmcl, ciwpmcl, clwpmcl, reicmcl, relqmcl, taucmcl,
-            ssacmcl, asmcmcl, fsfcmcl) = _rrtmg_sw.climlab_mcica_subcol_sw(
-                            ncol, nlay, icld, permuteseed, irng, play,
-                            cldfrac, ciwp, clwp, reic, relq, tauc, ssac, asmc, fsfc)
-        #  Call the RRTMG_SW driver to compute radiative fluxes
-        (swuflx, swdflx, swhr, swuflxc, swdflxc, swhrc) = \
-            _rrtmg_sw.climlab_rrtmg_sw(ncol, nlay, icld, iaer,
-                play, plev, tlay, tlev, tsfc,
-                h2ovmr, o3vmr, co2vmr, ch4vmr, n2ovmr, o2vmr,
-                asdir, asdif, aldir, aldif,
-                coszen, adjes, dyofyr, scon, isolvar,
-                inflgsw, iceflgsw, liqflgsw, cldfmcl,
-                taucmcl, ssacmcl, asmcmcl, fsfcmcl,
-                ciwpmcl, clwpmcl, reicmcl, relqmcl,
-                tauaer, ssaaer, asmaer, ecaer,
-                bndsolvar, indsolvar, solcycfrac)
+
+        n_rrtmg_repeat = self.n_rrtmg_repeat if (icld == 0 and self.do_seed_permutation) else 1
+        for ind_rrtmg_call in range(n_rrtmg_repeat):
+            if icld == 0:  # clear-sky only
+                cldfmcl = np.zeros((ngptsw,ncol,nlay))
+                ciwpmcl = np.zeros((ngptsw,ncol,nlay))
+                clwpmcl = np.zeros((ngptsw,ncol,nlay))
+                reicmcl = np.zeros((ncol,nlay))
+                relqmcl = np.zeros((ncol,nlay))
+                taucmcl = np.zeros((ngptsw,ncol,nlay))
+                ssacmcl = np.zeros((ngptsw,ncol,nlay))
+                asmcmcl = np.zeros((ngptsw,ncol,nlay))
+                fsfcmcl = np.zeros((ngptsw,ncol,nlay))
+            else:
+                #  Call the Monte Carlo Independent Column Approximation (McICA, Pincus et al., JC, 2003)
+                if self.do_seed_permutation:
+                    seed = permuteseed + (n_rrtmg_repeat * self.time['steps'] + ind_rrtmg_call) * ngptsw
+                else:
+                    seed = permuteseed
+                if ncol == 1 or not self.do_col_by_col:
+                    (cldfmcl, ciwpmcl, clwpmcl, reicmcl, relqmcl, taucmcl,
+                    ssacmcl, asmcmcl, fsfcmcl) = _rrtmg_sw.climlab_mcica_subcol_sw(
+                                ncol, nlay, icld, seed, irng, play,
+                                cldfrac, ciwp, clwp, reic, relq, tauc, ssac, asmc, fsfc)
+                else:
+                    cldfmcl = np.zeros((ngptsw,ncol,nlay))
+                    ciwpmcl = np.zeros((ngptsw,ncol,nlay))
+                    clwpmcl = np.zeros((ngptsw,ncol,nlay))
+                    reicmcl = np.zeros((ncol,nlay))
+                    relqmcl = np.zeros((ncol,nlay))
+                    taucmcl = np.zeros((ngptsw,ncol,nlay))
+                    ssacmcl = np.zeros((ngptsw,ncol,nlay))
+                    asmcmcl = np.zeros((ngptsw,ncol,nlay))
+                    fsfcmcl = np.zeros((ngptsw,ncol,nlay))
+                    for icol in range(ncol):
+                        (cldfmcl1, ciwpmcl1, clwpmcl1, reicmcl1, relqmcl1, taucmcl1, ssacmcl1, asmcmcl1, fsfcmcl1) = \
+                            _rrtmg_sw.climlab_mcica_subcol_sw(1, nlay, icld, seed, irng, play[np.newaxis,icol,:],
+                                cldfrac[np.newaxis,icol,:], ciwp[np.newaxis,icol,:], clwp[np.newaxis,icol,:], reic[np.newaxis,icol,:], relq[np.newaxis,icol,:], tauc[:,np.newaxis, icol,:], ssac[:,np.newaxis, icol,:], asmc[:,np.newaxis, icol,:], fsfc[:,np.newaxis, icol,:])
+                        cldfmcl[:,icol,:] = cldfmcl1[:,0,:]
+                        ciwpmcl[:,icol,:] = ciwpmcl1[:,0,:]
+                        clwpmcl[:,icol,:] = clwpmcl1[:,0,:]
+                        reicmcl[icol,:] = reicmcl1[0,:]
+                        relqmcl[icol,:] = relqmcl1[0,:]
+                        taucmcl[:,icol,:] = taucmcl1[:,0,:]
+                        ssacmcl[:,icol,:] = ssacmcl1[:,0,:]
+                        asmcmcl[:,icol,:] = asmcmcl1[:,0,:]
+                        fsfcmcl[:,icol,:] = fsfcmcl1[:,0,:]
+            #  Call the RRTMG_SW driver to compute radiative fluxes
+            (swuflx1, swdflx1, swhr1, swuflxc1, swdflxc1, swhrc1) = \
+                _rrtmg_sw.climlab_rrtmg_sw(ncol, nlay, icld, iaer,
+                    play, plev, tlay, tlev, tsfc,
+                    h2ovmr, o3vmr, co2vmr, ch4vmr, n2ovmr, o2vmr,
+                    asdir, asdif, aldir, aldif,
+                    coszen, adjes, dyofyr, scon, isolvar,
+                    inflgsw, iceflgsw, liqflgsw, cldfmcl,
+                    taucmcl, ssacmcl, asmcmcl, fsfcmcl,
+                    ciwpmcl, clwpmcl, reicmcl, relqmcl,
+                    tauaer, ssaaer, asmaer, ecaer,
+                    bndsolvar, indsolvar, solcycfrac)
+            if ind_rrtmg_call == 0:
+                swuflx = swuflx1 / n_rrtmg_repeat
+                swdflx = swdflx1 / n_rrtmg_repeat
+                swhr = swhr1 / n_rrtmg_repeat
+                swuflxc = swuflxc1 / n_rrtmg_repeat
+                swdflxc = swdflxc1 / n_rrtmg_repeat
+                swhrc = swhrc1 / n_rrtmg_repeat
+            else:
+                swuflx += swuflx1 / n_rrtmg_repeat
+                swdflx += swdflx1 / n_rrtmg_repeat
+                swhr += swhr1 / n_rrtmg_repeat
+                swuflxc += swuflxc1 / n_rrtmg_repeat
+                swdflxc += swdflxc1 / n_rrtmg_repeat
+                swhrc += swhrc1 / n_rrtmg_repeat
         #  Output is all (ncol,nlay+1) or (ncol,nlay)
         self.SW_flux_up = _rrtm_to_climlab(swuflx) + 0.*self.SW_flux_up
         self.SW_flux_down = _rrtm_to_climlab(swdflx) + 0.*self.SW_flux_down

--- a/climlab/tests/test_rrtmg_cld_sampling.py
+++ b/climlab/tests/test_rrtmg_cld_sampling.py
@@ -1,0 +1,95 @@
+from __future__ import division
+import numpy as np
+import climlab
+import pytest
+from copy import deepcopy
+
+num_lev = 50
+num_lat = 200
+
+cldfrac0 = 0.5  # layer cloud fraction
+r_liq = 14.  # Cloud water drop effective radius (microns)
+clwp = 60.  # in-cloud liquid water path (g/m2)
+ciwp = 0.  # in-cloud liquid water path (g/m2)
+r_ice = r_liq
+#  The cloud fraction is a Gaussian bump centered at level i
+p0 = 500.0
+cloud_dp = 100.0
+flux_variability_expectation = 1.0
+
+small_num = 1e-11
+
+#  State variables (Air and surface temperature)
+state = climlab.column_state(num_lev=num_lev, num_lat = num_lat, water_depth=1.)
+state_1d = climlab.column_state(num_lev=num_lev, water_depth=1.)
+lev = state.Tatm.domain.axes['lev'].points
+lat = state.Tatm.domain.axes['lat'].points
+
+ind_p = np.argmin(lev-p0)
+
+
+cldfrac = np.repeat((cldfrac0 * np.exp(-(lev-lev[ind_p])**2/(2*cloud_dp)**2))[np.newaxis,:], num_lat, axis=0)
+#  Define some local cloud characteristics
+mycloud = {'cldfrac': cldfrac + np.zeros_like(state.Tatm),
+            'clwp': np.zeros_like(state.Tatm) + clwp,
+            'r_liq': np.zeros_like(state.Tatm) + r_liq,
+            'ciwp': np.zeros_like(state.Tatm) + ciwp,
+            'r_ice': np.zeros_like(state.Tatm) + r_ice}
+mycloud_1d = {k: v[0,:] for k,v in mycloud.items()}
+
+insolation = climlab.constants.S0 / 4 * np.ones((num_lat, 1))
+shared_param_dict = {'state': state, **mycloud, 'insolation': insolation}
+shared_param_dict_1d = {'state': state_1d, **mycloud_1d, 'insolation': insolation[0,:]}
+
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_cloud_sampling_approached():
+    rad_no_clouds = climlab.radiation.RRTMG(**shared_param_dict, icld=0)
+    rad_default = climlab.radiation.RRTMG(**shared_param_dict)
+    rad_no_rand1 = climlab.radiation.RRTMG(**shared_param_dict, icld=1, do_col_by_col=True)
+    rad_seed_permut = climlab.radiation.RRTMG(**shared_param_dict, do_seed_permutation=True)
+    # rad_no_rand2 = climlab.radiation.RRTMG(**shared_param_dict, icld=3) # presumed to have no randomization, but that doesn't seem to be the case
+    rad_avg_results = climlab.radiation.RRTMG(**shared_param_dict_1d, do_seed_permutation=True, n_rrtmg_repeat=num_lat)
+
+    O3 = rad_no_clouds.absorber_vmr['O3']
+    O3_avg = np.average(O3, weights=np.cos(np.deg2rad(lat)), axis=0)
+    O3_flat = np.repeat(O3_avg[np.newaxis,:], num_lat, axis=0)
+    rad_seed_permut_t1 = deepcopy(rad_seed_permut)
+    rad_seed_permut_t1.time['steps'] += 1
+    rad_default_t1 = deepcopy(rad_default)
+    rad_default_t1.time['steps'] += 1
+    rad_list = [rad_no_clouds, rad_default, rad_no_rand1, rad_seed_permut_t1, rad_default_t1]
+    for rad in rad_list:
+        rad.absorber_vmr['O3'] = O3_flat
+        rad.compute_diagnostics()
+    rad_avg_results.absorber_vmr['O3'] = O3_flat[0,:]
+    rad_avg_results.compute_diagnostics()
+
+    # radiation has no varibaility between columns without clouds
+    assert(np.all(np.std(rad_no_clouds.SW_flux_net, axis=0) < small_num))
+    assert(np.all(np.std(rad_no_clouds.LW_flux_net, axis=0) < small_num))
+
+    std_sw_default = np.std(rad_default.SW_flux_net, axis=0)
+    std_lw_default = np.std(rad_default.LW_flux_net, axis=0)
+    mean_sw_default = np.mean(rad_default.SW_flux_net, axis=0)
+    mean_lw_default = np.mean(rad_default.LW_flux_net, axis=0)
+
+    # reflecting variability between columns due to using different seeds on the grid
+    assert(np.all(std_sw_default > flux_variability_expectation))
+    assert(np.all(std_lw_default > flux_variability_expectation))
+    
+    # not expected to randomize between differemt columns for col_by_col mode
+    assert(np.all(np.std(rad_no_rand1.SW_flux_net, axis=0) < small_num))
+    assert(np.all(np.std(rad_no_rand1.LW_flux_net, axis=0) < small_num))
+
+    # not expected to randomize between time steps
+    assert(np.all(rad_default_t1.SW_flux_net - rad_default.SW_flux_net == 0.0))
+    assert(np.all(rad_default_t1.LW_flux_net - rad_default.LW_flux_net == 0.0))
+
+    # after time stepping seed_permut expected to have variability between time steps
+    assert(np.all(np.std(rad_seed_permut_t1.SW_flux_net - rad_seed_permut.SW_flux_net, axis=0) > flux_variability_expectation))
+    assert(np.all(np.std(rad_seed_permut_t1.LW_flux_net - rad_seed_permut.LW_flux_net, axis=0) > flux_variability_expectation))
+
+    # check variability reduction in averaged case
+    assert(np.all(np.abs(rad_avg_results.SW_flux_net - mean_sw_default) < 2 / np.sqrt(num_lat) * std_sw_default))
+    assert(np.all(np.abs(rad_avg_results.LW_flux_net - mean_lw_default) < 2 / np.sqrt(num_lat) * std_lw_default))


### PR DESCRIPTION
This PR is in relation to issue #226. Among the features:
1. Avoiding cloud related variability across columns when setting do_col_by_col=True
2. Introducing evolving seed (as a function of number of calls to rrtmg). The seed is shifted in each call by ngpts, as recommended in the comments in "generate_stochastic_clouds". This feature is turned on by setting do_seed_permutation=True.
3. Allowing for multiple calls to rrtmg within a given call to compute, and averaging over the resulting fluxes. This feature is turned on by setting n_rrtmg_repeat > 1 (the number of calls to rrtmg).