### PR TITLE
Add SimplifiedBettsMiller convection process

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
-        os: [Ubuntu, macOS, Windows]
+        python-version: ['3.9', '3.10', '3.11']
+        os: [Ubuntu, macOS]
         include:
           - os: Ubuntu
             environment-file: environment.yml
@@ -26,9 +26,6 @@ jobs:
           - os: macOS
             environment-file: environment.yml
             shell: bash -l {0}
-          - os: Windows
-            environment-file: environment.yml
-            shell: powershell
 
     steps:
       - uses: actions/checkout@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-22.9"
 
 conda:
   environment: docs/environment.yml

--- a/climlab/convection/__init__.py
+++ b/climlab/convection/__init__.py
@@ -8,3 +8,4 @@ For a full convection scheme including interactive water vapor, use :class:`~cli
 from __future__ import absolute_import
 from .convadj import ConvectiveAdjustment
 from .emanuel_convection import EmanuelConvection
+from .simplified_betts_miller import SimplifiedBettsMiller

--- a/climlab/convection/simplified_betts_miller.py
+++ b/climlab/convection/simplified_betts_miller.py
@@ -1,0 +1,149 @@
+'''
+A climlab process for the Frierson Simplified Betts Miller convection scheme
+'''
+import numpy as np
+import warnings
+from climlab.process import TimeDependentProcess
+from climlab.utils.thermo import qsat
+from climlab import constants as const
+from climlab.domain.field import Field
+from climlab.domain import zonal_mean_column
+# The array conversion routines
+#from climlab.radiation.rrtm.utils import _climlab_to_rrtm as _climlab_to_convect
+#from climlab.radiation.rrtm.utils import _rrtm_to_climlab as _convect_to_climlab
+try:
+    from climlab_sbm_convection import betts_miller
+except:
+    warnings.warn('Cannot import SimplifiedBettsMiller fortran extension, this module will not be functional.')
+
+HLv = const.Lhvap
+Cp_air = const.cp
+Grav = const.g
+rdgas = const.Rd
+rvgas = const.Rv
+kappa = const.kappa
+es0 = 1.0
+
+
+class SimplifiedBettsMiller(TimeDependentProcess):
+    '''
+    to do
+    '''
+    def __init__(self,
+                tau_bm=7200.,
+                rhbm=0.8,
+                do_simp=False,
+                do_shallower=True,
+                do_changeqref=True,
+                do_envsat=True,
+                do_taucape=False,
+                capetaubm=900.,  # only used if do_taucape == True
+                tau_min=2400.,   # only used if do_taucape == True
+                **kwargs):
+        super(SimplifiedBettsMiller, self).__init__(**kwargs)
+        self.time_type = 'explicit'
+        #  Define inputs and diagnostics
+        surface_shape = self.state['Tatm'][...,0].shape
+        #  Hack to handle single column and multicolumn
+        if surface_shape == ():
+            init = np.atleast_1d(np.zeros(surface_shape))
+            self.multidim=False
+        else:
+            init = np.zeros(surface_shape)[...,np.newaxis]
+            self.multidim=True
+        init = Field(init, domain=self.state.Ts.domain)
+        self.add_diagnostic('precipitation', init*0.) # Precip rate (kg/m2/s)
+        self.add_diagnostic('cape', init*0.)
+        self.add_diagnostic('cin', init*0.)
+        self.add_input('tau_bm', tau_bm)
+        self.add_input('rhbm', rhbm)
+        self.add_input('capetaubm', capetaubm)
+        self.add_input('tau_min', tau_min)
+        self.add_input('do_simp', do_simp)
+        self.add_input('do_shallower', do_shallower)
+        self.add_input('do_changeqref', do_changeqref)
+        self.add_input('do_envsat', do_envsat)
+        self.add_input('do_taucape', do_taucape)
+        if hasattr(rhbm, 'shape'):
+            assert np.all(rhbm.shape == self.Tatm.shape), f'rhbm {rhbm.shape} has to have same shape as Tatm {self.Tatm.shape}'
+            self.rhbm = rhbm
+        else:
+            self.rhbm = rhbm * np.ones_like(self.Tatm)
+
+        self._KX = self.lev.size
+        try:
+            self._JX = self.lat.size
+        except:
+            self._JX = 1
+        try:
+            self._IX = self.lon.size
+        except:
+            self._IX = 1
+
+    def _climlab_to_sbm(self, field):
+        '''Prepare field with proper dimension order.
+        Betts-Miller code expects 3D arrays with (IX, JX, KX)
+        and 2D arrays with (IX, JX).
+        climlab grid dimensions are any of:
+            - (KX,)
+            - (JX, KX)
+            - (JX, IX, KX)
+        '''
+        if np.isscalar(field):
+            return field
+        else:
+            num_dims = len(field.shape)
+            if num_dims==1:  #  (num_lev only)
+                return np.tile(field, [self._IX, self._JX, 1])
+            elif num_dims==2:  # (num_lat, num_lev)
+                return np.tile(field, [self._IX, 1, 1])
+            else:  # assume we have (num_lon, num_lat, num_lev)
+                return field
+    
+    def _sbm_to_climlab(self, field):
+        ''' Output is either (IX, JX, KX) or (IX, JX).
+        Transform this to...
+            - (KX,) or (1,)  if IX==1 and JX==1
+            - (IX,KX) or (IX, 1)   if IX>1 and JX==1
+            - no change if IX>1, JX>1
+        '''
+        return np.squeeze(field)
+
+    def _compute(self):
+        #  Convection code expects that first element on pressure axis is TOA
+        #  which is the same as climlab convention.
+        #  All we have to do is ensure the input fields are (num_lat, num_lon, num_lev)
+        T = self._climlab_to_sbm(self.state['Tatm'])
+        RHBM = self._climlab_to_sbm(self.rhbm)
+        dom = self.state['Tatm'].domain
+        P = self._climlab_to_sbm(dom.lev.points) * 100. # convert to Pascals
+        PH = self._climlab_to_sbm(dom.lev.bounds) * 100.
+        Q = self._climlab_to_sbm(self.state['q'])
+        dt = self.timestep
+
+        (rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, \
+        invtau_bm_t, invtau_bm_q, capeflag) = \
+            betts_miller(dt, T, Q, RHBM, P, PH,
+                         HLv,Cp_air,Grav,rdgas,rvgas,kappa, es0,
+                         self.tau_bm, self.do_simp, self.do_shallower,
+                         self.do_changeqref, self.do_envsat, self.do_taucape,
+                         self.capetaubm, self.tau_min,self._IX, self._JX, self._KX, )
+
+        # Routine returns adjustments rather than tendencies
+        dTdt = tdel / dt
+        dQdt = qdel / dt
+        tendencies = {'Tatm': self._sbm_to_climlab(dTdt)*np.ones_like(self.state['Tatm']),
+                      'q': self._sbm_to_climlab(dQdt)*np.ones_like(self.state['q'])}
+        if 'Ts' in self.state:
+            tendencies['Ts'] = 0. * self.state['Ts']
+        #  Need to convert from kg/m2 (mm) to kg/m2/s (mm/s)
+        #  Hack to handle single column and multicolumn
+        if self.multidim:
+            self.precipitation[:,0] = self._sbm_to_climlab(rain)/dt
+            self.cape[:,0] = self._sbm_to_climlab(cape)
+            self.cin[:,0] = self._sbm_to_climlab(cin)
+        else:
+            self.precipitation[:] = self._sbm_to_climlab(rain)/dt
+            self.cape[:] = self._sbm_to_climlab(cape)
+            self.cin[:] = self._sbm_to_climlab(cin)
+        return tendencies

--- a/climlab/convection/simplified_betts_miller.py
+++ b/climlab/convection/simplified_betts_miller.py
@@ -22,9 +22,8 @@ A climlab process for the Frierson Simplified Betts Miller convection scheme
             equilibrium will be determined by the interactions between 
             moist convection, radiation, and surface fluxes::
 
-                from climlab.surface import SensibleHeatFlux, LatentHeatFlux
-                from climlab.radiation import RRTMG, DailyInsolation, AnnualMeanInsolation
-                from climlab import couple
+                import numpy as np
+                import climlab
                 from climlab.utils import constants as const
 
                 num_lev = 30
@@ -51,19 +50,19 @@ A climlab process for the Frierson Simplified Betts Miller convection scheme
 
                 temperature_state = {'Tatm':full_state.Tatm,'Ts':full_state.Ts}
                 #  Surface model
-                shf = SensibleHeatFlux(name='Sensible Heat Flux',
+                shf = climlab.surface.SensibleHeatFlux(name='Sensible Heat Flux',
                                     state=temperature_state, Cd=3E-3,
                                     timestep=short_timestep)
-                lhf = LatentHeatFlux(name='Latent Heat Flux',
+                lhf = climlab.surface.LatentHeatFlux(name='Latent Heat Flux',
                                     state=full_state, Cd=3E-3,
                                     timestep=short_timestep)
-                surface = couple([shf,lhf], name="Slab")
+                surface = climlab.couple([shf,lhf], name="Slab")
                 #  Convection scheme -- water vapor is a state variable
-                conv = SimplifiedBettsMiller(name='Convection',
+                conv = climlab.convection.SimplifiedBettsMiller(name='Convection',
                                             state=full_state,
                                             timestep=short_timestep,
                                         )  
-                rad = RRTMG(name='Radiation',
+                rad = climlab.radiation.RRTMG(name='Radiation',
                                 state=temperature_state,
                                 specific_humidity=full_state.q,  # water vapor is an input here, not a state variable
                                 albedo=albedo,
@@ -71,8 +70,8 @@ A climlab process for the Frierson Simplified Betts Miller convection scheme
                                 timestep=long_timestep,
                                 icld=0, # no clouds
                                 )
-                atm = couple([rad, conv], name='Atmosphere')
-                moistmodel = couple([atm,surface], name='Moist column model')
+                atm = climlab.couple([rad, conv], name='Atmosphere')
+                moistmodel = climlab.couple([atm,surface], name='Moist column model')
 
                 print(moistmodel)
             

--- a/climlab/convection/simplified_betts_miller.py
+++ b/climlab/convection/simplified_betts_miller.py
@@ -120,7 +120,29 @@ es0 = 1.0
 
 class SimplifiedBettsMiller(TimeDependentProcess):
     '''
-    to do
+    The climlab wrapper for Dargan Frierson's Simplified Betts Miller moist 
+    convection scheme (Frierson 2007, J. Atmos. Sci. 64, doi:10.1175/JAS3935.1)
+
+    Basic characteristics:
+
+    State:
+
+    - Tatm (air temperature in K)
+    - q (specific humidity in kg/kg)
+
+    Input arguments and default values:
+
+    - ``tau_bm = 7200.``: Betts-Miller relaxation timescale (seconds)
+    - ``rhbm = 0.8``: relative humidity profile to which the scheme is relaxing
+    - ``do_simp = False``: do the simple method where you adjust timescales to make precip continuous always.    
+    - ``do_shallower = True``: do the shallow convection scheme where it chooses a smaller depth such that precipitation is zero.
+    - ``do_changeqref = True``: do the shallow convection scheme where it changes the profile of both q and T in order make precip zero.
+    - ``do_envsat = True``: reference profile is rhbm times saturated wrt environment (if false, it's rhbm times parcel).
+    - ``do_taucape = False``: scheme where taubm is proportional to CAPE**-1/2
+    - ``capetaubm = 900.``: for the above scheme, the value of CAPE (J/kg) for which tau = tau_bm. Ignored unless ``do_taucape == True``.
+    - ``tau_min = 2400.``: for the above scheme, the minimum relaxation time allowed (seconds). Ignored unless ``do_taucape == True``.
+
+    See Frierson (2007) for more details.
     '''
     def __init__(self,
                 tau_bm=7200.,

--- a/climlab/tests/test_sbm_convection.py
+++ b/climlab/tests/test_sbm_convection.py
@@ -1,16 +1,80 @@
 import numpy as np
 import climlab
 from climlab.convection import SimplifiedBettsMiller
+from climlab.surface import SensibleHeatFlux, LatentHeatFlux
+from climlab.radiation import RRTMG
+from climlab import couple
 from climlab.tests.xarray_test import to_xarray
 import pytest
 
 
-@pytest.mark.compiled
-@pytest.mark.fast
-def test_sbm_column():
+def make_initial_column():
+    '''Create a single column state dictionary with initial conditions'''
     num_lev = 30
     water_depth = 10.
     full_state = climlab.column_state(water_depth=water_depth, num_lev=num_lev)
+    # set initial conditions -- 24C at the surface, -60C at 200 hPa, isothermal stratosphere
+    strat_idx = 6
+    Tinitial = np.zeros(num_lev)
+    Tinitial[:strat_idx] = -60. + const.tempCtoK
+    Tinitial[strat_idx:] = np.linspace(-60, 22, num_lev-strat_idx) + const.tempCtoK
+    Tsinitial = 24. + const.tempCtoK
+
+    full_state = climlab.column_state(water_depth=water_depth, num_lev=num_lev)
+    full_state['Tatm'][:] = Tinitial
+    full_state['Ts'][:] = Tsinitial
+
+    # Use Manabe's profile as an initial condition for specific humidity
+    Q = full_state['Tatm'].domain.axes['lev'].points / const.ps
+    RHprofile = 0.7 * ((Q-0.02) / (1-0.02))
+    e = climlab.utils.thermo.clausius_clapeyron(full_state['Tatm']) * RHprofile
+    qStrat = 5.E-6
+    qinitial = np.maximum(qStrat, e/full_state['Tatm'].domain.axes['lev'].points * const.Rd / const.Rv)
+    full_state['q'] = 0.*full_state.Tatm + qinitial
+    return full_state
+
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_sbm_column():
+    full_state = make_initial_column()
     conv = SimplifiedBettsMiller(name='Convection',
                                  state=full_state,)
     conv.step_forward()
+
+
+def test_moist_column():
+    '''This test sets up a complete single-column model.
+    The initial condition is completely dry.
+    We test to see if the column moistens itself via surface evaporation and convection'''
+    full_state = make_initial_column()
+    short_timestep = const.seconds_per_hour * 3
+    long_timestep = short_timestep*3
+    insolation = 342.
+    albedo = 0.18
+    temperature_state = {'Tatm':full_state.Tatm,'Ts':full_state.Ts}
+    #  Surface model
+    shf = SensibleHeatFlux(name='Sensible Heat Flux',
+                        state=temperature_state, Cd=3E-3,
+                        timestep=short_timestep)
+    lhf = LatentHeatFlux(name='Latent Heat Flux',
+                        state=full_state, Cd=3E-3,
+                        timestep=short_timestep)
+    surface = couple([shf,lhf], name="Slab")
+    #  Convection scheme -- water vapor is a state variable
+    conv = SimplifiedBettsMiller(name='Convection',
+                                state=full_state,
+                                timestep=short_timestep,
+                            )  
+    rad = RRTMG(name='Radiation',
+                    state=temperature_state,
+                    specific_humidity=full_state.q,  # water vapor is an input here, not a state variable
+                    albedo=albedo,
+                    insolation=insolation,
+                    timestep=long_timestep,
+                    icld=0, # no clouds
+                    )
+    atm = couple([rad, conv], name='Atmosphere')
+    moistmodel = couple([atm,surface], name='Moist column model')
+
+    moistmodel.step_forward()
+    

--- a/climlab/tests/test_sbm_convection.py
+++ b/climlab/tests/test_sbm_convection.py
@@ -78,10 +78,10 @@ def moist_column():
 
 @pytest.mark.compiled
 @pytest.mark.fast
-def test_moist_column(moistmodel):
+def test_moist_column(moist_column):
     '''This test sets up a complete single-column model.
     The initial condition is completely dry.
     We test to see if the column moistens itself via surface evaporation and convection.
     
     Actually a basic test to see if we can create a single column and step forward.'''
-    moistmodel.step_forward()
+    moist_column.step_forward()

--- a/climlab/tests/test_sbm_convection.py
+++ b/climlab/tests/test_sbm_convection.py
@@ -5,6 +5,7 @@ from climlab.surface import SensibleHeatFlux, LatentHeatFlux
 from climlab.radiation import RRTMG
 from climlab import couple
 from climlab.tests.xarray_test import to_xarray
+from climlab.utils import constants as const
 import pytest
 
 
@@ -77,4 +78,3 @@ def test_moist_column():
     moistmodel = couple([atm,surface], name='Moist column model')
 
     moistmodel.step_forward()
-    

--- a/climlab/tests/test_sbm_convection.py
+++ b/climlab/tests/test_sbm_convection.py
@@ -42,11 +42,9 @@ def test_sbm_column():
                                  state=full_state,)
     conv.step_forward()
 
-
-def test_moist_column():
-    '''This test sets up a complete single-column model.
-    The initial condition is completely dry.
-    We test to see if the column moistens itself via surface evaporation and convection'''
+@pytest.fixture()
+def moist_column():
+    '''Set up a complete single-column model.'''
     full_state = make_initial_column()
     short_timestep = const.seconds_per_hour * 3
     long_timestep = short_timestep*3
@@ -76,5 +74,14 @@ def test_moist_column():
                     )
     atm = couple([rad, conv], name='Atmosphere')
     moistmodel = couple([atm,surface], name='Moist column model')
+    return moistmodel
 
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_moist_column(moistmodel):
+    '''This test sets up a complete single-column model.
+    The initial condition is completely dry.
+    We test to see if the column moistens itself via surface evaporation and convection.
+    
+    Actually a basic test to see if we can create a single column and step forward.'''
     moistmodel.step_forward()

--- a/climlab/tests/test_sbm_convection.py
+++ b/climlab/tests/test_sbm_convection.py
@@ -1,0 +1,16 @@
+import numpy as np
+import climlab
+from climlab.convection import SimplifiedBettsMiller
+from climlab.tests.xarray_test import to_xarray
+import pytest
+
+
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_sbm_column():
+    num_lev = 30
+    water_depth = 10.
+    full_state = climlab.column_state(water_depth=water_depth, num_lev=num_lev)
+    conv = SimplifiedBettsMiller(name='Convection',
+                                 state=full_state,)
+    conv.step_forward()

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,3 +21,4 @@ dependencies:
   - climlab-rrtmg
   - climlab-cam3-radiation
   - climlab-emanuel-convection
+  - climlab-sbm-convection

--- a/docs/source/api/climlab.convection.SimplifiedBettsMiller.rst
+++ b/docs/source/api/climlab.convection.SimplifiedBettsMiller.rst
@@ -1,0 +1,11 @@
+SimplifiedBettsMiller
+---------------------
+
+.. inheritance-diagram:: climlab.convection.SimplifiedBettsMiller
+   :parts: 1
+   :private-bases:
+
+.. automodule:: climlab.convection.simplified_betts_miller
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/climlab.convection.rst
+++ b/docs/source/api/climlab.convection.rst
@@ -11,3 +11,4 @@ climlab.convection
 
     climlab.convection.convadj
     climlab.convection.EmanuelConvection
+    climlab.convection.SimplifiedBettsMiller

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -163,9 +163,7 @@ bibtex_bibfiles = ['bibliography.bib']
 #     import sphinx_rtd_theme
 #     html_theme = 'sphinx_rtd_theme'
 #     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,8 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinxcontrib.bibtex',
     'numpydoc',
-    'nbsphinx'
+    'nbsphinx',
+    'sphinx_rtd_theme',
 ]
 
 nbsphinx_execute = 'never'
@@ -157,11 +158,14 @@ bibtex_bibfiles = ['bibliography.bib']
 
 # -- Options for HTML output ----------------------------------------------
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+# if not on_rtd:  # only import and set the theme if we're building docs locally
+#     import sphinx_rtd_theme
+#     html_theme = 'sphinx_rtd_theme'
+#     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - climlab-rrtmg
   - climlab-emanuel-convection
   - climlab-cam3-radiation
+  - climlab-sbm-convection


### PR DESCRIPTION
This PR adds a new process to climlab for the Simplified Betts Miller convection scheme (Frierson 2007).

The convection code itself and a basic Python wrapper are at https://github.com/climlab/climlab-sbm-convection/. This PR adds Python code for a climlab-native Process object `climlab.convection.SimplifiedBettsMiller` that can be coupled to radiation etc.

Still to do:

- [x] Write some tests
- [x] Make sure tests are passing
- [x] Add some basic example usage
- [x] Add to the climlab docs