### PR TITLE
Temporary pin to previous climlab-rrtmg

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
-  - climlab-rrtmg
+  - climlab-rrtmg <0.3
   - climlab-emanuel-convection
   - climlab-cam3-radiation
   - climlab-sbm-convection


### PR DESCRIPTION
This will keep the tests passing on main branch until #235 is done and we're ready to fully support zenith angle averaging.