### PR TITLE
Pin to previous sphinx version due to nbsphinx incompatibility

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - netCDF4
   - xarray
   - pooch
-  - sphinx
+  - sphinx <8.2
   - ipython
   - jupyter
   - future


### PR DESCRIPTION
This PR is an attempt to get the docs building again.

Builds on readthedocs are currently failing with
```
    Traceback (most recent call last):
      File "/home/docs/checkouts/readthedocs.org/user_builds/climlab/conda/241/lib/python3.12/site-packages/sphinx/events.py", line 404, in emit
        results.append(listener.handler(self.app, *args))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/climlab/conda/241/lib/python3.12/site-packages/nbsphinx/__init__.py", line 1714, in html_collect_pages
        sphinx.util.console.brown, len(files)):
        ^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/climlab/conda/241/lib/python3.12/site-packages/sphinx/util/__init__.py", line 157, in __getattr__
        raise AttributeError(msg)
    AttributeError: module 'sphinx.util' has no attribute 'console'
```

Seems to be related to https://github.com/sphinx-doc/sphinx/issues/13393 and https://github.com/sphinx-doc/sphinx/issues/13346

Checking to see here if pinning to Sphinx < 8.2 will resolve the problem for now.