### PR TITLE
Fully support and test coszen weighting options

### DIFF
--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -278,6 +278,10 @@ class AnnualMeanInsolation(_Insolation):
     :func:`~climlab.solar.insolation.daily_insolation_factors` and stored in the
     diagnostics ``insolation``, ``coszen``, and ``irrandiance_factor``.
 
+    Different daily averaging methods can be specified for the zenith angle via the 
+    ``weighting`` argument. See :func:`~climlab.solar.insolation.daily_insolation_factors`
+    for more details.
+
     **Initialization parameters** \n
 
     :param float ``S0``:    solar constant                                       \n
@@ -301,6 +305,11 @@ class AnnualMeanInsolation(_Insolation):
 
                             * unit: degrees
                             * default value: ``23.446``
+
+    :param str ``weighting``:   flag to specify daily averaging method for solar zenith angle. Valid options are: \n
+                            - ``'time'`` (default): unweighted 24 hour daily average
+                            - ``'sunlit'``: time average over sunlit hours
+                            - ``'insolation'``: insolation-weighted average
 
     **Object attributes** \n
 
@@ -375,9 +384,10 @@ class AnnualMeanInsolation(_Insolation):
 
     """
     def __init__(self, S0=const.S0, orb=const.orb_present, 
-                 **kwargs):
+                 weighting='time', **kwargs):
         super(AnnualMeanInsolation, self).__init__(S0=S0, **kwargs)
         self.orb = orb
+        self.weighting = weighting
         self._compute_fixed()
     
     @property
@@ -408,7 +418,8 @@ class AnnualMeanInsolation(_Insolation):
     def _daily_insolation_factor_arrays(self):
         coszen, irradiance_factor = daily_insolation_factors(self.lat,
                                                              self.time['days_of_year'],
-                                                             orb=self.orb,)
+                                                             orb=self.orb,
+                                                             weighting=self.weighting)
         return coszen, irradiance_factor
 
     def _compute_fixed(self):
@@ -448,6 +459,10 @@ class DailyInsolation(AnnualMeanInsolation):
     to compute solar zenith angle and adjustments to total irradiance. 
     See there for details on how the solar distribution depends on orbital parameters.
 
+    Different daily averaging methods can be specified for the zenith angle via the 
+    ``weighting`` argument. See :func:`~climlab.solar.insolation.daily_insolation_factors`
+    for more details.
+
     **Initialization parameters** \n
 
     :param float S0:    solar constant                              \n
@@ -470,6 +485,11 @@ class DailyInsolation(AnnualMeanInsolation):
 
                             * unit: degrees
                             * default value: ``23.446``
+
+    :param str ``weighting``:   flag to specify daily averaging method for solar zenith angle. Valid options are: \n
+                            - ``'time'`` (default): unweighted 24 hour daily average
+                            - ``'sunlit'``: time average over sunlit hours
+                            - ``'insolation'``: insolation-weighted average
 
     **Object attributes** \n
 

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -1,4 +1,4 @@
-r"""
+"""
 Classes to provide insolation as input for other CLIMLAB processes.
 
 Options include

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -195,46 +195,46 @@ def test_latitude():
     assert np.all(grad[0:(int(num_lat/2)-1)] > 0.)
     assert np.all(grad[int(num_lat/2):] < 0.)
 
-# @pytest.mark.compiled
-# @pytest.mark.fast
-# def test_cozen():
-#     '''
-#     Create 2D models with RRTMG radiation and latitudinally-varying radiation.
-#     Check to see that different ways of time-averaging the solar zenith angle
-#     result in different ASR despite same insolation
-#     due to zenith-angle dependence of clear-sky scattering
-#     '''
-#     num_lat = 180
-#     model_list = []
-#     for weighting in ['time', 'sunlit', 'insolation']:
-#         #  State variables (Air and surface temperature)
-#         state = climlab.column_state(num_lev=30, num_lat=num_lat, water_depth=1.)
-#         #  insolation using specified zenith angle weighting
-#         sol = climlab.radiation.AnnualMeanInsolation(name='Insolation',
-#                                                  domains=state.Ts.domain,
-#                                                  weighting=weighting)
-#         #  radiation module with insolation as input
-#         #   Set icld=0 for clear-sky only (no need to call cloud overlap routine)
-#         rad = climlab.radiation.RRTMG(name='Radiation', state=state, icld=0,
-#                                       S0=sol.S0,
-#                                       coszen=sol.coszen,
-#                                       irradiance_factor=sol.irradiance_factor)
-#         #  Couple everything together
-#         m = climlab.couple([rad, sol], name='model')
-#         m.compute_diagnostics()
-#         model_list.append(m)
-#     # Do all models that the same insolation?
-#     assert np.allclose(model_list[0].insolation, model_list[1].insolation)
-#     assert np.allclose(model_list[1].insolation, model_list[2].insolation)
-#     # Does the cosine of zenith angle increase as we weight the average towards times of day with more insolation?
-#     assert np.all(model_list[0].coszen < model_list[1].coszen)
-#     assert np.all(model_list[1].coszen < model_list[2].coszen)
-#     # Does the ASR increase for higher zenith angle (away from the poles)?
-#     ASR0 = climlab.to_xarray(model_list[0].ASR)
-#     ASR1 = climlab.to_xarray(model_list[1].ASR)
-#     ASR2 = climlab.to_xarray(model_list[2].ASR)
-#     assert ((ASR1-ASR0).sel(lat=slice(-75,75)) > 0.).all()
-#     assert ((ASR2-ASR1).sel(lat=slice(-75,75)) > 0.).all()
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_cozen():
+    '''
+    Create 2D models with RRTMG radiation and latitudinally-varying radiation.
+    Check to see that different ways of time-averaging the solar zenith angle
+    result in different ASR despite same insolation
+    due to zenith-angle dependence of clear-sky scattering
+    '''
+    num_lat = 180
+    model_list = []
+    for weighting in ['time', 'sunlit', 'insolation']:
+        #  State variables (Air and surface temperature)
+        state = climlab.column_state(num_lev=30, num_lat=num_lat, water_depth=1.)
+        #  insolation using specified zenith angle weighting
+        sol = climlab.radiation.AnnualMeanInsolation(name='Insolation',
+                                                 domains=state.Ts.domain,
+                                                 weighting=weighting)
+        #  radiation module with insolation as input
+        #   Set icld=0 for clear-sky only (no need to call cloud overlap routine)
+        rad = climlab.radiation.RRTMG(name='Radiation', state=state, icld=0,
+                                      S0=sol.S0,
+                                      coszen=sol.coszen,
+                                      irradiance_factor=sol.irradiance_factor)
+        #  Couple everything together
+        m = climlab.couple([rad, sol], name='model')
+        m.compute_diagnostics()
+        model_list.append(m)
+    # Do all models that the same insolation?
+    assert np.allclose(model_list[0].insolation, model_list[1].insolation)
+    assert np.allclose(model_list[1].insolation, model_list[2].insolation)
+    # Does the cosine of zenith angle increase as we weight the average towards times of day with more insolation?
+    assert np.all(model_list[0].coszen < model_list[1].coszen)
+    assert np.all(model_list[1].coszen < model_list[2].coszen)
+    # Does the ASR increase for higher zenith angle (away from the poles)?
+    ASR0 = climlab.to_xarray(model_list[0].ASR)
+    ASR1 = climlab.to_xarray(model_list[1].ASR)
+    ASR2 = climlab.to_xarray(model_list[2].ASR)
+    assert ((ASR1-ASR0).sel(lat=slice(-75,75)) > 0.).all()
+    assert ((ASR2-ASR1).sel(lat=slice(-75,75)) > 0.).all()
 
 @pytest.mark.compiled
 @pytest.mark.fast


### PR DESCRIPTION
This PR finished the abandoned work from #235 which was separated from #243. Trying to add full support for different time-averaging options for the cosine of the zenith angle.