### PR TITLE
Test on Python 3.13

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [Ubuntu, macOS]
         include:
           - os: Ubuntu

--- a/README.rst
+++ b/README.rst
@@ -96,15 +96,12 @@ These are handled automatically if you install with conda_.
 
 Required
 ~~~~~~~~~~~~
-- Python (currently testing on versions 3.8, 3.9, 3.10, 3.11)
+- Python (currently testing on versions 3.10, 3.11, 3.12, 3.13)
 - numpy
 - scipy
 - future
 - pooch (for remote data access and caching)
 - xarray (for data handling)
-
-
-*climlab will still run on Python 2.7 on some systems but we are no longer supporting this*
 
 Recommended for full functionality
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -96,14 +96,12 @@ These are handled automatically if you install with conda_.
 
 Required
 ------------
-- Python (currently testing on versions 3.8, 3.9, 3.10, 3.11)
+- Python (currently testing on versions 3.10, 3.11, 3.12, 3.13)
 - numpy
 - scipy
 - future
 - pooch (for remote data access and caching)
 - xarray (for data handling)
-
-*climlab will still run on Python 2.7 on some systems but we are no longer supporting this*
 
 Recommended for full functionality
 ----------------------------------


### PR DESCRIPTION
This should fail until the Python 3.13 build for climlab-rrtmg is available on conda-forge (in progress).