### PR TITLE
Remove legacy Python 2 code

### DIFF
--- a/climlab/convection/__init__.py
+++ b/climlab/convection/__init__.py
@@ -5,7 +5,6 @@ For simple adjustment of temperature to a prescribed lapse rate, use :class:`~cl
 
 For a full convection scheme including interactive water vapor, use :class:`~climlab.convection.EmanuelConvection`
 '''
-from __future__ import absolute_import
 from .convadj import ConvectiveAdjustment
 from .emanuel_convection import EmanuelConvection
 from .simplified_betts_miller import SimplifiedBettsMiller

--- a/climlab/convection/akmaev_adjustment.py
+++ b/climlab/convection/akmaev_adjustment.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 from climlab import constants as const
 import sys

--- a/climlab/convection/convadj.py
+++ b/climlab/convection/convadj.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from builtins import range
 import numpy as np
 from climlab import constants as const

--- a/climlab/convection/emanuel_convection.py
+++ b/climlab/convection/emanuel_convection.py
@@ -1,8 +1,6 @@
 '''
 A climlab process for the Emanuel convection scheme
 '''
-from __future__ import absolute_import
-
 import numpy as np
 import warnings
 from climlab.process import TimeDependentProcess

--- a/climlab/domain/axis.py
+++ b/climlab/domain/axis.py
@@ -1,6 +1,4 @@
-from __future__ import division
-from builtins import str
-from builtins import object
+from builtins import str, object
 import numpy as np
 from climlab import constants as const
 

--- a/climlab/domain/domain.py
+++ b/climlab/domain/domain.py
@@ -1,6 +1,4 @@
-from __future__ import division
-from builtins import str
-from builtins import object
+from builtins import str, object
 from climlab.domain.axis import Axis
 from climlab.utils import heat_capacity
 

--- a/climlab/domain/field.py
+++ b/climlab/domain/field.py
@@ -5,7 +5,6 @@
 # Following a tutorial on subclassing ndarray here:
 #
 # http://docs.scipy.org/doc/numpy/user/basics.subclassing.html
-from __future__ import division
 import numpy as np
 from climlab.domain.xarray import Field_to_xarray
 

--- a/climlab/domain/initial.py
+++ b/climlab/domain/initial.py
@@ -1,5 +1,4 @@
 """Convenience routines for setting up initial conditions."""
-from __future__ import division
 import numpy as np
 from climlab.domain import domain
 from climlab.domain.field import Field

--- a/climlab/domain/xarray.py
+++ b/climlab/domain/xarray.py
@@ -1,4 +1,3 @@
-from __future__ import division, absolute_import
 from builtins import str
 from builtins import object
 from xarray import Dataset, DataArray

--- a/climlab/dynamics/__init__.py
+++ b/climlab/dynamics/__init__.py
@@ -24,7 +24,6 @@ meridional diffusion process down the zonal-mean surface temperature gradient.
 with transport down an approximate gradient in near-surface moist static energy.
 '''
 
-from __future__ import absolute_import
 from .budyko_transport import BudykoTransport
 from .advection_diffusion import AdvectionDiffusion, Diffusion
 from .meridional_advection_diffusion import MeridionalAdvectionDiffusion, MeridionalDiffusion

--- a/climlab/dynamics/adv_diff_numerics.py
+++ b/climlab/dynamics/adv_diff_numerics.py
@@ -241,7 +241,6 @@ to handle multidimensional input. The key assumption is that
 Inputs should be reshaped appropriately (e.g. with ``numpy.moveaxis()``)
 before calling these functions.
 '''
-from __future__ import division
 from numpy import zeros, ones, zeros_like, ones_like, matmul, diag, diag_indices, diff, newaxis
 from numpy.linalg import solve
 from scipy.linalg import solve_banded

--- a/climlab/dynamics/advection_diffusion.py
+++ b/climlab/dynamics/advection_diffusion.py
@@ -43,7 +43,6 @@ will operate along a single dimension only.
 
 Other classes implement the weighting for spherical geometry.
 """
-from __future__ import division
 import numpy as np
 from climlab.process.implicit import ImplicitProcess
 from climlab.process.process import get_axes

--- a/climlab/dynamics/budyko_transport.py
+++ b/climlab/dynamics/budyko_transport.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from climlab.process.energy_budget import EnergyBudget
 from climlab.domain.field import global_mean
 

--- a/climlab/dynamics/meridional_advection_diffusion.py
+++ b/climlab/dynamics/meridional_advection_diffusion.py
@@ -32,7 +32,6 @@ Non-uniform grid spacing is supported.
 The state variable :math:`\psi` may be multi-dimensional, but the diffusion
 will operate along the latitude dimension only.
 """
-from __future__ import division
 import numpy as np
 from .advection_diffusion import AdvectionDiffusion, Diffusion
 from climlab import constants as const

--- a/climlab/dynamics/meridional_heat_diffusion.py
+++ b/climlab/dynamics/meridional_heat_diffusion.py
@@ -35,7 +35,6 @@ Non-uniform grid spacing is supported.
 The state variable :math:`T` may be multi-dimensional, but the diffusion
 will operate along the latitude dimension only.
 """
-from __future__ import division
 import numpy as np
 from .meridional_advection_diffusion import MeridionalDiffusion
 from climlab import constants as const

--- a/climlab/dynamics/meridional_moist_diffusion.py
+++ b/climlab/dynamics/meridional_moist_diffusion.py
@@ -116,7 +116,6 @@ we can calculate the diffusion coefficient :math:`D(\phi)` from this formula.
 
 This calculation is implemented in the ``MeridionalMoistDiffusion`` class.
 """
-from __future__ import division
 import numpy as np
 from .meridional_heat_diffusion import MeridionalHeatDiffusion
 from climlab.utils.thermo import qsat

--- a/climlab/model/column.py
+++ b/climlab/model/column.py
@@ -34,7 +34,6 @@ This model is now a single column with seasonally varying insolation
 calculated for 45N.
 
 """
-from __future__ import division
 import numpy as np
 from climlab import constants as const
 from climlab.process import TimeDependentProcess

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -76,7 +76,6 @@ We can run both models out to equilibrium and compare the results as follows:
             plt.show()
 
 """
-from __future__ import division
 import numpy as np
 from math import pi
 from climlab import constants as const

--- a/climlab/model/stommelbox.py
+++ b/climlab/model/stommelbox.py
@@ -4,8 +4,6 @@
 
 # how easy is to implement the Stommel 1961 box model in climlab?
 #  currently... it still requires a fair bit of code:
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 from climlab.process.time_dependent_process import TimeDependentProcess
 from climlab.domain import domain, field

--- a/climlab/process/__init__.py
+++ b/climlab/process/__init__.py
@@ -1,5 +1,4 @@
 '''The base classes for all climlab processes.'''
-from __future__ import absolute_import
 from .process import Process, process_like, get_axes
 from .time_dependent_process import TimeDependentProcess, couple
 from .implicit import ImplicitProcess

--- a/climlab/process/diagnostic.py
+++ b/climlab/process/diagnostic.py
@@ -1,5 +1,4 @@
-from __future__ import division
-from climlab.process.time_dependent_process import TimeDependentProcess
+from .time_dependent_process import TimeDependentProcess
 
 
 class DiagnosticProcess(TimeDependentProcess):

--- a/climlab/process/energy_budget.py
+++ b/climlab/process/energy_budget.py
@@ -1,6 +1,5 @@
-from __future__ import division
 import numpy as np
-from climlab.process.time_dependent_process import TimeDependentProcess
+from .time_dependent_process import TimeDependentProcess
 
 
 class EnergyBudget(TimeDependentProcess):

--- a/climlab/process/external_forcing.py
+++ b/climlab/process/external_forcing.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from .time_dependent_process import TimeDependentProcess
 
 class ExternalForcing(TimeDependentProcess):

--- a/climlab/process/implicit.py
+++ b/climlab/process/implicit.py
@@ -1,5 +1,4 @@
-from __future__ import division
-from climlab.process.time_dependent_process import TimeDependentProcess
+from .time_dependent_process import TimeDependentProcess
 
 
 class ImplicitProcess(TimeDependentProcess):

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -63,7 +63,6 @@
 #         - anything in the `input` dictionary of `subprocname` will remain fixed
 #==============================================================================
 
-from __future__ import division, print_function
 from builtins import object
 import time, copy
 import numpy as np

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import print_function
 from builtins import str
 from builtins import range
 import numpy as np

--- a/climlab/radiation/__init__.py
+++ b/climlab/radiation/__init__.py
@@ -2,8 +2,6 @@
 Modules for radiative transfer in vertical columns,
 along with processes for insolation and fixed relative humidity.
 '''
-from __future__ import absolute_import
-
 from .aplusbt import AplusBT, AplusBT_CO2
 from .absorbed_shorwave import SimpleAbsorbedShortwave
 from .boltzmann import Boltzmann

--- a/climlab/radiation/absorbed_shorwave.py
+++ b/climlab/radiation/absorbed_shorwave.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 from climlab.process.energy_budget import EnergyBudget
 from climlab import constants as const
 

--- a/climlab/radiation/aplusbt.py
+++ b/climlab/radiation/aplusbt.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from climlab.process.energy_budget import EnergyBudget
 from climlab.utils import constants as const
 import numpy as np

--- a/climlab/radiation/boltzmann.py
+++ b/climlab/radiation/boltzmann.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from climlab import constants as const
 from climlab.process.energy_budget import EnergyBudget
 

--- a/climlab/radiation/cam3.py
+++ b/climlab/radiation/cam3.py
@@ -32,7 +32,6 @@ Input arguments and diagnostics follow specifications in
 
 
 '''
-from __future__ import division, print_function, absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.utils.thermo import vmr_to_mmr

--- a/climlab/radiation/greygas.py
+++ b/climlab/radiation/greygas.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from builtins import range
 import numpy as np
 from climlab.utils.thermo import blackbody_emission

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -18,7 +18,6 @@ At least three diagnostics are provided:
 - ``coszen``, cosine of the solar zenith angle (dimensionless)
 - ``irradiance_factor``, ratio of current total irradiance to its annual average, i.e. solar constant (dimensionless)
 """
-from __future__ import division
 import numpy as np
 from climlab.process.diagnostic import DiagnosticProcess
 from climlab.domain.field import Field, to_latlon

--- a/climlab/radiation/nband.py
+++ b/climlab/radiation/nband.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from builtins import range
 import numpy as np
 from climlab.radiation.greygas import GreyGas

--- a/climlab/radiation/radiation.py
+++ b/climlab/radiation/radiation.py
@@ -75,9 +75,6 @@ If ``return_spectral_olr = True`` (RRTMG only), an additional diagnostic is prod
 
     - ``OLR_spectral`` (W/m2, Outgoing Longwave Radiation at TOA in spectral bands, **positive up**)
 '''
-
-from __future__ import division
-from __future__ import print_function
 import numpy as np
 from climlab.process import EnergyBudget
 from climlab.radiation import ManabeWaterVapor

--- a/climlab/radiation/rrtm/__init__.py
+++ b/climlab/radiation/rrtm/__init__.py
@@ -33,7 +33,6 @@ See <http://rtweb.aer.com/rrtm_frame.html> for more information about the RRTMG 
             print(rcm.ASR - rcm.OLR)
 
 '''
-from __future__ import division, absolute_import
 from .rrtmg import RRTMG
 from .rrtmg_lw import RRTMG_LW
 from .rrtmg_sw import RRTMG_SW

--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.radiation.radiation import _Radiation_SW, _Radiation_LW

--- a/climlab/radiation/rrtm/rrtmg_lw.py
+++ b/climlab/radiation/rrtm/rrtmg_lw.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function, absolute_import
 import numpy as np
 import warnings
 from climlab import constants as const

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function, absolute_import
 import numpy as np
 import warnings
 from climlab import constants as const

--- a/climlab/radiation/rrtm/setup.py
+++ b/climlab/radiation/rrtm/setup.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-from __future__ import division, print_function
-
-
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('rrtm', parent_package, top_path)

--- a/climlab/radiation/rrtm/utils.py
+++ b/climlab/radiation/rrtm/utils.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 from scipy.interpolate import interp1d
 from climlab.utils.thermo import mmr_to_vmr

--- a/climlab/radiation/transmissivity.py
+++ b/climlab/radiation/transmissivity.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from builtins import object
 import numpy as np
 

--- a/climlab/radiation/water_vapor.py
+++ b/climlab/radiation/water_vapor.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 from climlab.process.diagnostic import DiagnosticProcess
 from climlab import constants as const

--- a/climlab/solar/insolation.py
+++ b/climlab/solar/insolation.py
@@ -35,7 +35,6 @@ and solar longitude, daily average insolation is calculated exactly
 following :cite:`Berger_1978`. Further references: :cite:`Berger_1991`.
 
 """
-from __future__ import division
 import numpy as np
 from climlab import constants as const
 from numpy import sqrt, deg2rad, rad2deg, sin, cos, tan, arcsin, arccos, pi

--- a/climlab/solar/orbital/__init__.py
+++ b/climlab/solar/orbital/__init__.py
@@ -34,7 +34,6 @@ See <http://vo.imcce.fr/insola/earth/online/earth/La2004/README.TXT>
             from climlab.solar.orbital.long import OrbitalTable as LongTable
             print(LongTable)
 """
-from __future__ import division, print_function, absolute_import
 import numpy as np
 import pandas as pd
 import xarray as xr

--- a/climlab/solar/orbital/long.py
+++ b/climlab/solar/orbital/long.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 import os, pooch
 import pandas as pd

--- a/climlab/solar/orbital/setup.py
+++ b/climlab/solar/orbital/setup.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import os
 
 

--- a/climlab/solar/orbital/table.py
+++ b/climlab/solar/orbital/table.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 import os, pooch
 import pandas as pd

--- a/climlab/solar/orbital_cycles.py
+++ b/climlab/solar/orbital_cycles.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import print_function
 from builtins import str
 from builtins import range
 from builtins import object

--- a/climlab/surface/__init__.py
+++ b/climlab/surface/__init__.py
@@ -6,6 +6,5 @@ processes that implement bulk aerodynamic fluxes for surface energy and water ex
 ``climlab.surface.albedo`` contains processes for surface albedo
 and interactive ice and snow lines for energy balance models.
 '''
-from __future__ import absolute_import
 from .turbulent import SensibleHeatFlux, LatentHeatFlux
 from .albedo import ConstantAlbedo, P2Albedo, Iceline, StepFunctionAlbedo

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from builtins import next
 import numpy as np
 from climlab.process.diagnostic import DiagnosticProcess

--- a/climlab/surface/surface_radiation.py
+++ b/climlab/surface/surface_radiation.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 from climlab import thermo
 from climlab.process.energy_budget import EnergyBudget

--- a/climlab/surface/turbulent.py
+++ b/climlab/surface/turbulent.py
@@ -54,7 +54,6 @@ occurs in the lowest atmospheric model level.
                 #  Check for energy balance
                 print(model.ASR - model.OLR)
 '''
-from __future__ import division
 import numpy as np
 from climlab.utils.thermo import qsat
 from climlab import constants as const

--- a/climlab/tests/test_advdiff_solver.py
+++ b/climlab/tests/test_advdiff_solver.py
@@ -1,5 +1,4 @@
 '''Tests for the 1D advection-diffusion solver against an analytical benchmark.'''
-from __future__ import division
 import numpy as np
 import pytest
 from climlab.dynamics import adv_diff_numerics

--- a/climlab/tests/test_bandrc.py
+++ b/climlab/tests/test_bandrc.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 import pytest

--- a/climlab/tests/test_cam3rad.py
+++ b/climlab/tests/test_cam3rad.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 from climlab.tests.xarray_test import to_xarray

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 import pytest

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 import pytest

--- a/climlab/tests/test_emanuel_convection.py
+++ b/climlab/tests/test_emanuel_convection.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 from climlab.convection import emanuel_convection

--- a/climlab/tests/test_grey_radiation.py
+++ b/climlab/tests/test_grey_radiation.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 import pytest

--- a/climlab/tests/test_insolation.py
+++ b/climlab/tests/test_insolation.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function, absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.solar.insolation import daily_insolation, daily_insolation_factors, instant_insolation, solar_longitude

--- a/climlab/tests/test_rcm.py
+++ b/climlab/tests/test_rcm.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 import pytest

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 import pytest

--- a/climlab/tests/test_thermo.py
+++ b/climlab/tests/test_thermo.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import climlab
 from climlab.utils import thermo

--- a/climlab/tests/xarray_test.py
+++ b/climlab/tests/xarray_test.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import climlab
 
 

--- a/climlab/utils/constants.py
+++ b/climlab/utils/constants.py
@@ -10,7 +10,6 @@
 
 """
 
-from __future__ import division
 from numpy import pi
 
 a = 6.373E6      # Radius of Earth (m)

--- a/climlab/utils/heat_capacity.py
+++ b/climlab/utils/heat_capacity.py
@@ -1,6 +1,5 @@
 """Routines for calculating heat capacities for grid boxes."""
 
-from __future__ import division
 from climlab import constants as const
 
 

--- a/climlab/utils/legendre.py
+++ b/climlab/utils/legendre.py
@@ -1,8 +1,6 @@
 """Can calculate the first several Legendre polynomials, along with
 (some of) their first derivatives."""
 
-from __future__ import division
-
 def Pn(x):
     """Calculate Legendre polyomials P0 to P28 and returns them
     in a dictionary ``Pn``.

--- a/climlab/utils/thermo.py
+++ b/climlab/utils/thermo.py
@@ -3,7 +3,6 @@ A collection of function definitions to handle common
 thermodynamic calculations for the atmosphere.
 """
 
-from __future__ import division
 from numpy import exp, log
 from .constants import (ps, kappa, tempCtoK, eps, Rd, Rv, cpv, cp, g, Lhvap,
                         sigma, hPlanck, c_light, kBoltzmann, molecular_weight)

--- a/climlab/utils/walk.py
+++ b/climlab/utils/walk.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 def walk_processes(top, topname='top', topdown=True, ignoreFlag=False):
     """Generator for recursive tree of climlab processes
 

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - xarray
   - numpy
   - scipy >=1.6
-  - future
   - pytest
   - codecov
   - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools, os
 
-VERSION = '0.9.0'
+VERSION = '0.9.1'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,
@@ -29,7 +29,6 @@ setuptools.setup(
     author='Brian E. J. Rose',
     author_email='brose@albany.edu',
     setup_requires=['numpy'],
-    install_requires=['numpy','xarray','scipy'],
     license='MIT',
     packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
This PR removes many many lines like
```
from __future__ import division
```
that were once necessary for simultaneous Python 2/3 support.