### PR TITLE
Fix propagation of solar constant parameter

### DIFF
--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -239,3 +239,12 @@ class RRTMG(_Radiation_SW, _Radiation_LW):
         # propagate to 'SW'
         if 'SW' in self.subprocess:
             self.subprocess['SW'].irradiance_factor = x
+
+    @property
+    def S0(self):
+        return self._S0
+    @S0.setter
+    def S0(self, x):
+        self._S0 = x
+        if 'SW' in self.subprocess:
+            self.subprocess['SW'].S0 = x

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -298,3 +298,5 @@ def test_sw_params_propagate():
     rad.irradiance_factor *= 1.01
     assert rad.irradiance_factor == rad.subprocess['SW'].irradiance_factor
     assert rad.insolation == rad.subprocess['SW'].insolation
+    rad.S0 *= 1.01
+    assert rad.S0 == rad.subprocess['SW'].S0


### PR DESCRIPTION
Closes #254 

First step is to add changes in parameter `S0` to the tests we are already doing for propagation of SW parameters for RRTMG processes. This should fail for now.