### PR TITLE
Specify insolation and coszen simultaneously

### DIFF
--- a/climlab/radiation/radiation.py
+++ b/climlab/radiation/radiation.py
@@ -218,7 +218,9 @@ class _Radiation_SW(_Radiation):
         self.add_input('coszen', coszen)
         self.add_input('irradiance_factor', irradiance_factor)
         if insolation is not None:
-            self.add_input('insolation', insolation)
+            # Avoid calling the `add_input` method because insolation is defined as property here
+            self._input_vars.append('insolation')
+            self.insolation = insolation
         if albedo is not None:
             aldif = albedo
             aldir = albedo

--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -1,29 +1,16 @@
 import numpy as np
 from climlab import constants as const
-from climlab.radiation.radiation import _Radiation #_Radiation_SW, _Radiation_LW
+from climlab.radiation.radiation import _Radiation_SW, _Radiation_LW
 from .rrtmg_lw import RRTMG_LW
 from .rrtmg_sw import RRTMG_SW, nbndsw
 
 
-# class RRTMG(_Radiation_SW, _Radiation_LW):
-class RRTMG(_Radiation):
+class RRTMG(_Radiation_SW, _Radiation_LW):
     '''Container to drive combined LW and SW radiation models.
 
     For some details about inputs and diagnostics, see the `radiation` module.
     '''
     def __init__(self,
-            # Defined in _Radiation_LW
-            emissivity = 1.,  # surface emissivity
-            # Defined in _Radiation_SW
-            albedo = None,
-            aldif = 0.3,
-            aldir = 0.3,
-            asdif = 0.3,
-            asdir = 0.3,
-            S0    = const.S0,
-            insolation = None,
-            coszen = 0.25,    # cosine of the solar zenith angle
-            irradiance_factor = 1.,  # instantaneous irradiance = S0 * irradiance_factor
             # GENERAL, used in both SW and LW
             icld = 1,    # Cloud overlap method, 0: Clear only, 1: Random, 2,  Maximum/random] 3: Maximum
             irng = 1,  # more monte carlo stuff
@@ -137,56 +124,21 @@ class RRTMG(_Radiation):
             **kwargs):
         super(RRTMG, self).__init__(**kwargs)
 
-        # # Remove specific inputs from kwargs dictionary.
-        # #  We want any changes implemented in the parent __init__ method to be preserved here
-        # remove_list = ['absorber_vmr','cldfrac','clwp','ciwp','r_liq','r_ice',
-        #                'emissivity','aldif','aldir','asdif','asdir','S0','coszen',
-        #                'irradiance_factor','insolation',]
-        # for item in remove_list:
-        #     if item in kwargs:
-        #         ignored = kwargs.pop(item)
+        # Remove specific inputs from kwargs dictionary.
+        #  We want any changes implemented in the parent __init__ method to be preserved here
+        remove_list = ['absorber_vmr','cldfrac','clwp','ciwp','r_liq','r_ice',
+                       'emissivity','aldif','aldir','asdif','asdir','S0','coszen',
+                       'irradiance_factor','insolation',]
+        for item in remove_list:
+            if item in kwargs:
+                ignored = kwargs.pop(item)
 
         # we need to convert insolation into _insolation so:
         # (we define getters and setters for this at the end)
-        # self._insolation = self.insolation
+        self._insolation = self.insolation
         
-        # # we repeat the above work to fix this issue for coszen
-        # self._coszen = self.coszen
-
-        self.add_input('emissivity', emissivity)
-
-        self.add_input('icld', icld)
-        self.add_input('irng', irng)
-        self.add_input('idrv', idrv)
-        self.add_input('permuteseed_sw', permuteseed_sw)
-        self.add_input('permuteseed_lw', permuteseed_lw)
-        self.add_input('dyofyr', dyofyr)
-        self.add_input('inflgsw', inflgsw)
-        self.add_input('inflglw', inflglw)
-        self.add_input('iceflgsw', iceflgsw)
-        self.add_input('iceflglw', iceflglw)
-        self.add_input('liqflgsw', liqflgsw)
-        self.add_input('liqflglw', liqflglw)
-        self.add_input('tauc_sw', tauc_sw)
-        self.add_input('tauc_lw', tauc_lw)
-        self.add_input('ssac_sw', ssac_sw)
-        self.add_input('asmc_sw', asmc_sw)
-        self.add_input('fsfc_sw', fsfc_sw)
-        self.add_input('tauaer_sw', tauaer_sw)
-        self.add_input('ssaaer_sw', ssaaer_sw)
-        self.add_input('asmaer_sw', asmaer_sw)
-        self.add_input('ecaer_sw', ecaer_sw)
-        self.add_input('tauaer_lw', tauaer_lw)
-        self.add_input('isolvar', isolvar)
-        self.add_input('indsolvar', indsolvar)
-        self.add_input('bndsolvar', bndsolvar)
-        self.add_input('solcycfrac', solcycfrac)
-
-        # self.add_input('S0', S0)
-        # self.add_input('coszen', coszen)
-        # self.add_input('irradiance_factor', irradiance_factor)
-        for var in ['S0', 'coszen', 'irradiance_factor']:
-            self._input_vars.append(var)
+        # we repeat the above work to fix this issue for coszen
+        self._coszen = self.coszen
 
         LW = RRTMG_LW(absorber_vmr = self.absorber_vmr,
                      cldfrac = self.cldfrac,
@@ -218,10 +170,9 @@ class RRTMG(_Radiation):
                      aldir = self.aldir,
                      asdif = self.asdif,
                      asdir = self.asdir,
-                     S0 = S0,
-                     coszen = coszen,
-                     irradiance_factor = irradiance_factor,
-                     insolation = insolation,
+                     S0 = self.S0,
+                     coszen = self.coszen,
+                     irradiance_factor = self.irradiance_factor,
                      dyofyr = dyofyr,
                      inflgsw = inflgsw,
                      iceflgsw = iceflgsw,
@@ -242,38 +193,58 @@ class RRTMG(_Radiation):
         self.add_subprocess('SW', SW)
         self.add_subprocess('LW', LW )
 
+        self.add_input('icld', icld)
+        self.add_input('irng', irng)
+        self.add_input('idrv', idrv)
+        self.add_input('permuteseed_sw', permuteseed_sw)
+        self.add_input('permuteseed_lw', permuteseed_lw)
+        self.add_input('dyofyr', dyofyr)
+        self.add_input('inflgsw', inflgsw)
+        self.add_input('inflglw', inflglw)
+        self.add_input('iceflgsw', iceflgsw)
+        self.add_input('iceflglw', iceflglw)
+        self.add_input('liqflgsw', liqflgsw)
+        self.add_input('liqflglw', liqflglw)
+        self.add_input('tauc_sw', tauc_sw)
+        self.add_input('tauc_lw', tauc_lw)
+        self.add_input('ssac_sw', ssac_sw)
+        self.add_input('asmc_sw', asmc_sw)
+        self.add_input('fsfc_sw', fsfc_sw)
+        self.add_input('tauaer_sw', tauaer_sw)
+        self.add_input('ssaaer_sw', ssaaer_sw)
+        self.add_input('asmaer_sw', asmaer_sw)
+        self.add_input('ecaer_sw', ecaer_sw)
+        self.add_input('tauaer_lw', tauaer_lw)
+        self.add_input('isolvar', isolvar)
+        self.add_input('indsolvar', indsolvar)
+        self.add_input('bndsolvar', bndsolvar)
+        self.add_input('solcycfrac', solcycfrac)
             
     @property
     def coszen(self):
-        # return self._coszen
-        return self.subprocess['SW'].coszen
+        return self._coszen
     @coszen.setter
     def coszen(self, x):
-        self.subprocess['SW'].coszen = x
-        # self._coszen = x
-        # # propagate to 'SW'
-        # if 'SW' in self.subprocess:
-        #     self.subprocess['SW'].coszen = x
+        self._coszen = x
+        # propagate to 'SW'
+        if 'SW' in self.subprocess:
+            self.subprocess['SW'].coszen = x
             
     @property
     def irradiance_factor(self):
-        # return self._irradiance_factor
-        return self.subprocess['SW'].irradiance_factor
+        return self._irradiance_factor
     @irradiance_factor.setter
     def irradiance_factor(self, x):
-        self.subprocess['SW'].irradiance_factor = x
-        # self._irradiance_factor = x
-        # # propagate to 'SW'
-        # if 'SW' in self.subprocess:
-        #     self.subprocess['SW'].irradiance_factor = x
+        self._irradiance_factor = x
+        # propagate to 'SW'
+        if 'SW' in self.subprocess:
+            self.subprocess['SW'].irradiance_factor = x
 
     @property
     def S0(self):
-        # return self._S0
-        return self.subprocess['SW'].S0
+        return self._S0
     @S0.setter
     def S0(self, x):
-        self.subprocess['SW'].S0 = x
-        # self._S0 = x
-        # if 'SW' in self.subprocess:
-        #     self.subprocess['SW'].S0 = x
+        self._S0 = x
+        if 'SW' in self.subprocess:
+            self.subprocess['SW'].S0 = x

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -196,6 +196,20 @@ def test_latitude():
 
 @pytest.mark.compiled
 @pytest.mark.fast
+def test_insolation_and_cozen():
+    '''Can we specific both insolation and coszen simultaneously?'''
+    state = climlab.column_state(num_lev=30, num_lat=40, water_depth=10.)
+    sun = climlab.radiation.DailyInsolation(name='Insolation', domains=state['Ts'].domain)
+    rad = climlab.radiation.RRTMG(name='Radiation',
+                                state=state, 
+                                albedo=0.125,
+                                insolation=sun.insolation,
+                                coszen=sun.coszen)
+    model = climlab.couple([rad,sun], name='RadModel')
+    model.step_forward()
+
+@pytest.mark.compiled
+@pytest.mark.fast
 def test_cozen():
     '''
     Create 2D models with RRTMG radiation and latitudinally-varying radiation.

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -202,8 +202,8 @@ def test_insolation_and_cozen():
     state = climlab.column_state(num_lev=30, num_lat=40, water_depth=10.)
     #  Specified relative humidity distribution
     h2o = climlab.radiation.ManabeWaterVapor(name='Fixed Relative Humidity', state=state)
-    #  Hard convective adjustment
-    conv = climlab.convection.ConvectiveAdjustment(name='Convective Adjustment', state=state, adj_lapse_rate=6.5)
+    # #  Hard convective adjustment
+    # conv = climlab.convection.ConvectiveAdjustment(name='Convective Adjustment', state=state, adj_lapse_rate=6.5)
     #  Daily insolation as a function of latitude and time of year
     sun = climlab.radiation.DailyInsolation(name='Insolation', domains=state['Ts'].domain)
     #  Couple the radiation to insolation and water vapor processes
@@ -213,7 +213,7 @@ def test_insolation_and_cozen():
                                 albedo=0.125,
                                 insolation=sun.insolation,
                                 coszen=sun.coszen)
-    model = climlab.couple([rad,sun,h2o,conv], name='RCM')
+    model = climlab.couple([rad,sun,h2o,], name='RCM')
     model.compute_diagnostics()
 
 @pytest.mark.compiled

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -198,15 +198,23 @@ def test_latitude():
 @pytest.mark.fast
 def test_insolation_and_cozen():
     '''Can we specific both insolation and coszen simultaneously?'''
+    # A two-dimensional domain
     state = climlab.column_state(num_lev=30, num_lat=40, water_depth=10.)
+    #  Specified relative humidity distribution
+    h2o = climlab.radiation.ManabeWaterVapor(name='Fixed Relative Humidity', state=state)
+    #  Hard convective adjustment
+    conv = climlab.convection.ConvectiveAdjustment(name='Convective Adjustment', state=state, adj_lapse_rate=6.5)
+    #  Daily insolation as a function of latitude and time of year
     sun = climlab.radiation.DailyInsolation(name='Insolation', domains=state['Ts'].domain)
+    #  Couple the radiation to insolation and water vapor processes
     rad = climlab.radiation.RRTMG(name='Radiation',
                                 state=state, 
+                                specific_humidity=h2o.q, 
                                 albedo=0.125,
                                 insolation=sun.insolation,
                                 coszen=sun.coszen)
-    model = climlab.couple([rad,sun], name='RadModel')
-    model.step_forward()
+    model = climlab.couple([rad,sun,h2o,conv], name='RCM')
+    model.compute_diagnostics()
 
 @pytest.mark.compiled
 @pytest.mark.fast


### PR DESCRIPTION
This PR will address #256 

First, add a new test that sets `coszen` and `insolation` simultaneously for an RRTMG process. 

Based on #256, this should fail on some platforms but maybe not all.