### PR TITLE
Better handling of insolation parameter inputs to RRTMG

### DIFF
--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -137,14 +137,16 @@ class RRTMG(_Radiation):
             **kwargs):
         super(RRTMG, self).__init__(**kwargs)
 
-        # # Remove specific inputs from kwargs dictionary.
-        # #  We want any changes implemented in the parent __init__ method to be preserved here
-        # remove_list = ['absorber_vmr','cldfrac','clwp','ciwp','r_liq','r_ice',
-        #                'emissivity','aldif','aldir','asdif','asdir','S0','coszen',
-        #                'irradiance_factor','insolation',]
-        # for item in remove_list:
-        #     if item in kwargs:
-        #         ignored = kwargs.pop(item)
+        # Remove specific inputs from kwargs dictionary.
+        #  We want any changes implemented in the parent __init__ method to be preserved here
+        remove_list = ['absorber_vmr','cldfrac','clwp','ciwp','r_liq','r_ice',
+                    #    'emissivity','aldif','aldir','asdif','asdir',
+                    #    'S0','coszen',
+                    #    'irradiance_factor','insolation',]
+                      ]   
+        for item in remove_list:
+            if item in kwargs:
+                ignored = kwargs.pop(item)
 
         # we need to convert insolation into _insolation so:
         # (we define getters and setters for this at the end)
@@ -198,7 +200,7 @@ class RRTMG(_Radiation):
                      irng = irng,
                      idrv = idrv,
                      permuteseed = permuteseed_lw,
-                     emissivity = self.emissivity,
+                     emissivity = emissivity,
                      inflglw = inflglw,
                      iceflglw = iceflglw,
                      liqflglw = liqflglw,
@@ -214,10 +216,11 @@ class RRTMG(_Radiation):
                      icld = icld,
                      irng = irng,
                      permute = permuteseed_sw,
-                     aldif = self.aldif,
-                     aldir = self.aldir,
-                     asdif = self.asdif,
-                     asdir = self.asdir,
+                     albedo = albedo,
+                     aldif = aldif,
+                     aldir = aldir,
+                     asdif = asdif,
+                     asdir = asdir,
                      S0 = S0,
                      coszen = coszen,
                      irradiance_factor = irradiance_factor,
@@ -277,3 +280,10 @@ class RRTMG(_Radiation):
         # self._S0 = x
         # if 'SW' in self.subprocess:
         #     self.subprocess['SW'].S0 = x
+
+    @property
+    def insolation(self):
+        return self.subprocess['SW'].insolation
+    @insolation.setter
+    def insolation(self, x):
+        self.subprocess['SW'].insolation = x

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -196,6 +196,20 @@ def test_latitude():
 
 @pytest.mark.compiled
 @pytest.mark.fast
+def test_insolation_and_cozen():
+    '''Can we specific both insolation and coszen simultaneously?'''
+    state = climlab.column_state(num_lev=30, num_lat=40, water_depth=10.)
+    sun = climlab.radiation.DailyInsolation(name='Insolation', domains=state['Ts'].domain)
+    rad = climlab.radiation.RRTMG(name='Radiation',
+                                state=state, 
+                                albedo=0.125,
+                                insolation=sun.insolation,
+                                coszen=sun.coszen)
+    model = climlab.couple([rad,sun], name='RadModel')
+    model.step_forward()
+
+@pytest.mark.compiled
+@pytest.mark.fast
 def test_cozen():
     '''
     Create 2D models with RRTMG radiation and latitudinally-varying radiation.

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -202,8 +202,8 @@ def test_insolation_and_cozen():
     state = climlab.column_state(num_lev=30, num_lat=40, water_depth=10.)
     #  Specified relative humidity distribution
     h2o = climlab.radiation.ManabeWaterVapor(name='Fixed Relative Humidity', state=state)
-    #  Hard convective adjustment
-    conv = climlab.convection.ConvectiveAdjustment(name='Convective Adjustment', state=state, adj_lapse_rate=6.5)
+    # #  Hard convective adjustment
+    # conv = climlab.convection.ConvectiveAdjustment(name='Convective Adjustment', state=state, adj_lapse_rate=6.5)
     #  Daily insolation as a function of latitude and time of year
     sun = climlab.radiation.DailyInsolation(name='Insolation', domains=state['Ts'].domain)
     #  Couple the radiation to insolation and water vapor processes
@@ -213,7 +213,7 @@ def test_insolation_and_cozen():
                                 albedo=0.125,
                                 insolation=sun.insolation,
                                 coszen=sun.coszen)
-    model = climlab.couple([rad,sun,h2o,conv], name='RCM')
+    model = climlab.couple([rad,sun,h2o,], name='RCM')
     model.compute_diagnostics()
 
 @pytest.mark.compiled

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -198,15 +198,23 @@ def test_latitude():
 @pytest.mark.fast
 def test_insolation_and_cozen():
     '''Can we specific both insolation and coszen simultaneously?'''
+    # A two-dimensional domain
     state = climlab.column_state(num_lev=30, num_lat=40, water_depth=10.)
+    #  Specified relative humidity distribution
+    h2o = climlab.radiation.ManabeWaterVapor(name='Fixed Relative Humidity', state=state)
+    #  Hard convective adjustment
+    conv = climlab.convection.ConvectiveAdjustment(name='Convective Adjustment', state=state, adj_lapse_rate=6.5)
+    #  Daily insolation as a function of latitude and time of year
     sun = climlab.radiation.DailyInsolation(name='Insolation', domains=state['Ts'].domain)
+    #  Couple the radiation to insolation and water vapor processes
     rad = climlab.radiation.RRTMG(name='Radiation',
                                 state=state, 
+                                specific_humidity=h2o.q, 
                                 albedo=0.125,
                                 insolation=sun.insolation,
                                 coszen=sun.coszen)
-    model = climlab.couple([rad,sun], name='RadModel')
-    model.step_forward()
+    model = climlab.couple([rad,sun,h2o,conv], name='RCM')
+    model.compute_diagnostics()
 
 @pytest.mark.compiled
 @pytest.mark.fast


### PR DESCRIPTION
This PR closes https://github.com/climlab/climlab/issues/256

(Replaces #257)

First, add a new test that sets coszen and insolation simultaneously for an RRTMG process. This fails for Linux but not for Mac (not clear why).

This PR introduces some refactoring of the `climlab.radiation.RRTMG` process to handle insolation inputs better.